### PR TITLE
Misc fixes

### DIFF
--- a/src/b2aiprep/cli.py
+++ b/src/b2aiprep/cli.py
@@ -34,8 +34,8 @@ def main():
 
 @main.command()
 @click.argument("filename", type=click.Path(exists=True))
-@click.option("-s", "--subject", type=ty.Optional[str], default=None)
-@click.option("-t", "--task", type=ty.Optional[str], default=None)
+@click.option("-s", "--subject", type=str, default=None)
+@click.option("-t", "--task", type=str, default=None)
 @click.option("--outdir", type=click.Path(), default=os.getcwd(), show_default=True)
 @click.option("--save_figures/--no-save_figures", default=False, show_default=True)
 @click.option("--n_mels", type=int, default=20, show_default=True)

--- a/src/b2aiprep/process.py
+++ b/src/b2aiprep/process.py
@@ -5,7 +5,7 @@ import typing as ty
 import warnings
 from hashlib import md5
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import matplotlib.pyplot as plt
 import opensmile
@@ -484,7 +484,7 @@ class SpeechToText:
             device=device,
         )
 
-    def transcribe(self, audio: Audio, language: str = None):
+    def transcribe(self, audio: Audio, language: Optional[str] = None):
         """
         Transcribes the given audio input into text.
 


### PR DESCRIPTION
- Typing optional fields with click did not work for me - I received `TypeError: Cannot instantiate typing.Union` (implicitly caused by using `Optional` which is shorthand for `typing.Union[str, None]`)
- added an optional type on one of the intermediate utilities