### PR TITLE
Update README.md to specify bids_dir parameter in Streamlit example

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,6 @@ b2aiprep-cli prepsummerdata \
 A dashboard is provided to help navigate the data in the BIDS format. Launch the dashboard from the repository folder with:
 
 ```sh
-streamlit run src/b2aiprep/app/Dashboard.py
+streamlit run src/b2aiprep/app/Dashboard.py [path to BIDS directory]
 ```
+After the Streamlit dashboard opens, please wait for the BIDS data to be loaded while on the Dashboard page, as an error regarding a non-initialized `bids_dir` directory may pop up if the BIDS data has not been fully loaded.


### PR DESCRIPTION
This is a simple documentation-specific pull request for `README.md`.

Specifically, the further specification of how `Streamlit` should be run, with a `bids_dir` argument being passed & notes a possible error regarding non-initialized `bids_dir` data whilst using `Streamlit`.

Specifically, the following simple changes are proposed for `README.md`:
`streamlit run src/b2aiprep/app/Dashboard.py`
to
`streamlit run src/b2aiprep/app/Dashboard.py [path to BIDS directory]`

Lastly, a note was added regarding a possible bug encountered whilst attempting to use `Streamlit`:
`After the Streamlit dashboard opens, please wait for the BIDS data to be loaded while on the Dashboard page, as an error regarding a non-initialized bids_dir directory may pop up if the BIDS data has not been fully loaded.`