### PR TITLE
enh: refactor options for prepare_bids 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10, <3.13"
 dependencies = [
-    "senselab~=0.18.0",
+    "senselab~=0.22.0",
     "matplotlib>=3.8.3",
     "fhir.resources==7.1.0",
     "streamlit"

--- a/src/b2aiprep/prepare/prepare.py
+++ b/src/b2aiprep/prepare/prepare.py
@@ -272,7 +272,7 @@ def extract_features_workflow(
     if "size" in df.columns:
         df = df[df["size"] <= np.percentile(df["size"].values, percentile)]
     if subject_id is not None:
-        df = df[df["path"].apply(lambda x: subject_id in str(x))]
+        df = df[df["subject"] == subject_id]
     # randomize to distribute sizes
     df = df.sample(frac=1).reset_index(drop=True)
     audio_paths = df.path.values.tolist()

--- a/src/b2aiprep/prepare/prepare.py
+++ b/src/b2aiprep/prepare/prepare.py
@@ -224,6 +224,7 @@ def extract_features_workflow(
     address: str = None,
     cache_dir: str | os.PathLike = None,
     percentile: int = 100,
+    subject_id: str = None,
 ):
     """Run a Pydra workflow to extract audio features from BIDS-like directory.
 
@@ -252,7 +253,7 @@ def extract_features_workflow(
     import multiprocessing as mp
 
     try:
-        mp.set_start_method('spawn', force=True)
+        mp.set_start_method("spawn", force=True)
     except RuntimeError:
         # Already set
         pass
@@ -270,6 +271,8 @@ def extract_features_workflow(
         return
     if "size" in df.columns:
         df = df[df["size"] <= np.percentile(df["size"].values, percentile)]
+    if subject_id is not None:
+        df = df[df["path"].apply(lambda x: subject_id in str(x))]
     # randomize to distribute sizes
     df = df.sample(frac=1).reset_index(drop=True)
     audio_paths = df.path.values.tolist()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,14 +44,20 @@ def test_prepare_bids_cli(setup_temp_files):
     command = [
         "b2aiprep-cli",
         "prepare-bids",
-        redcap_csv_path,
-        audio_dir,
         bids_dir_path,
+        "--redcap_csv_path",
+        redcap_csv_path,
+        "--audio_dir_path",
+        audio_dir,
+        "--tar_file_path",
         tar_file_path,
+        "-t",
         "tiny",  # transcription_model_size
-        "--n_cores", "2",
+        "--n_cores",
+        "2",
         "--with_sensitive",
         "--overwrite",
+        "--validate",
     ]
 
     # Run the CLI command


### PR DESCRIPTION
to support single subject processing 

```shell
b2aiprep-cli prepare-bids bids -t large-v3-turbo -n 4 --with_sensitive -s <subject id>
```

hopefully this will help with parallel generation on the cluster. 

also refactored task selection (see docstring for details)