### PR TITLE
127 update setup.py and readme to ensure arm python on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ A simple Python package to prepare acoustic data for the Bridge2AI voice project
 **Caution:** this package is under active development and interfaces may change rapidly.
 
 ## Installation
+
+MacOS with Mx (ARM) chip only: Make sure that you have the ARM version of python installed.
+Run this to check:
+```
+[path/to/your/python] -c "import platform; print(platform.machine())
+```
+
 Requires a Python >= 3.10, <3.12 environment
 
 ```
@@ -68,7 +75,7 @@ b2aiprep-cli --help
 
     Outfile is the path to and name of the csv file to be generated, e.g. `audiofiles.csv`
 
-   The csv file will have a header named `filename` with all the filenames listed under. 
+   The csv file will have a header named `filename` with all the filenames listed under.
 
 5. Verify if two audio files are from the same speaker
 
@@ -95,7 +102,7 @@ b2aiprep-cli --help
     b2aiprep-cli transcribe data/vc_source.wav
     ```
 
-    Or use a different model. Note that the large model may take some time to download. 
+    Or use a different model. Note that the large model may take some time to download.
 
     ```bash
     b2aiprep-cli transcribe data/vc_source.wav --model_id 'openai/whisper-large-v3' --return_timestamps true

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,15 @@
+import platform
+import sys
+
 from setuptools import setup
 
 import versioneer
+
+# Make sure the system is ARM64 if on macOS
+if platform.system() == "Darwin" and platform.machine() != "arm64":
+    sys.stderr.write(
+        "Error: This package requires an ARM64 architecture on macOS since pytorch 2.2.2+ does not support x86-64 on macOS\n"
+    )
+    sys.exit(1)
 
 setup(version=versioneer.get_version(), cmdclass=versioneer.get_cmdclass())


### PR DESCRIPTION
Updates the README to inform macOS users that they need an ARM version of python.
Adds a check when installed on macOS to ensure that the python used is for ARM.
