### PR TITLE
patch for release v2.0.0

### DIFF
--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -606,7 +606,9 @@ def publish_bids_dataset(bids_path, outdir):
                 record_id = item['answer'][0]['valueString']
                 item['answer'][0]['valueString'] = reduce_id_length(record_id)
                 participant_id = item['answer'][0]['valueString']
-            elif item['linkId'] == 'session_id':
+                # rename to participant_id
+                item['linkId'] = 'participant_id'
+            elif (item['linkId'] == 'session_id') or (item['linkId'].endswith('_session_id')):
                 item['answer'][0]['valueString'] = reduce_id_length(
                     item['answer'][0]['valueString']
                 )

--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -57,6 +57,7 @@ from b2aiprep.prepare.prepare import (
     extract_features_workflow,
     filter_audio_paths,
     get_value_from_metadata,
+    reduce_id_length,
     reduce_length_of_id,
     update_metadata_record_and_session_id,
     validate_bids_data,
@@ -461,6 +462,18 @@ def create_derived_dataset(bids_path, outdir):
 
         # sort the dataset by identifier and task_name
         ds = Dataset.from_generator(audio_feature_generator, num_proc=1)
+
+        # reduce length of participant_id and session_id
+        ds = ds.map(
+            partial(
+                lambda x: {
+                    'participant_id': reduce_id_length(x['participant_id']),
+                    'session_id': reduce_id_length(x['session_id']),
+                }
+            ),
+            remove_columns=['participant_id', 'session_id'],
+        )
+
         ds.to_parquet(
             str(outdir.joinpath(f"{feature_name}.parquet")),
             version="2.6",

--- a/src/b2aiprep/prepare/derived_data.py
+++ b/src/b2aiprep/prepare/derived_data.py
@@ -238,10 +238,9 @@ def clean_phenotype_data(df: pd.DataFrame, phenotype: dict) -> t.Tuple[pd.DataFr
     return df, phenotype
 
 def _rename_record_id_to_participant_id(df: pd.DataFrame, phenotype: dict) -> dict:
-    df = df.rename(columns={"record_id": "participant_id"})
     phenotype_updated = {}
     for c in df.columns:
-        if c == 'record_id':
+        if c in ('record_id', 'participant_id'):
             if c not in phenotype:
                 # for some reason record_id is not in many of the phenotype dict
                 phenotype['participant_id'] = {
@@ -252,6 +251,9 @@ def _rename_record_id_to_participant_id(df: pd.DataFrame, phenotype: dict) -> di
         else:
             phenotype_updated[c] = phenotype[c]
     phenotype = phenotype_updated
+
+    df = df.rename(columns={"record_id": "participant_id"})
+
     return df, phenotype
 
 def _add_sex_at_birth_column(df: pd.DataFrame, phenotype: dict) -> t.Tuple[pd.DataFrame, dict]:

--- a/src/b2aiprep/prepare/derived_data.py
+++ b/src/b2aiprep/prepare/derived_data.py
@@ -293,6 +293,7 @@ def load_phenotype_data(base_path: Path, phenotype_name: str) -> t.Tuple[pd.Data
         phenotype_name = phenotype_name[:-4]
     elif phenotype_name.endswith('.json'):
         phenotype_name = phenotype_name[:-5]
+
     df = pd.read_csv(base_path.joinpath(f"{phenotype_name}.tsv"), sep="\t")
     with open(base_path.joinpath(f"{phenotype_name}.json"), "r") as f:
         phenotype = json.load(f)
@@ -314,14 +315,14 @@ def load_phenotype_data(base_path: Path, phenotype_name: str) -> t.Tuple[pd.Data
     # fix some data values and remove columns we do not want to publish at this time
     df, phenotype = clean_phenotype_data(df, phenotype)
 
-    # create columns missing in the original data
-    if ("gender_identity" in df.columns) and ("specify_gender_identity" in df.columns):
-        df, phenotype = _add_sex_at_birth_column(df, phenotype)
-
     # reduce record_id to 8 characters
     df = reduce_length_of_id(df, id_name='record_id')
     df = reduce_length_of_id(df, id_name='session_id')
 
     df, phenotype = _rename_record_id_to_participant_id(df, phenotype)
+
+    # create columns missing in the original data
+    if ("gender_identity" in df.columns) and ("specify_gender_identity" in df.columns):
+        df, phenotype = _add_sex_at_birth_column(df, phenotype)
 
     return df, phenotype

--- a/src/b2aiprep/prepare/derived_data.py
+++ b/src/b2aiprep/prepare/derived_data.py
@@ -41,9 +41,6 @@ def spectrogram_generator(
         spectrogram = spectrogram[:, ::2]
         output["spectrogram"] = spectrogram
 
-        output["participant_id"] = reduce_id_length(output["participant_id"])
-        output["session_id"] = reduce_id_length(output["session_id"])
-
         yield output
 
 
@@ -133,9 +130,6 @@ def feature_extraction_generator(
 
         data = data[:, ::2]
         output[feature_name] = data
-
-        output["participant_id"] = reduce_id_length(output["participant_id"])
-        output["session_id"] = reduce_id_length(output["session_id"])
 
         yield output
 

--- a/src/b2aiprep/prepare/derived_data.py
+++ b/src/b2aiprep/prepare/derived_data.py
@@ -9,6 +9,7 @@ import torch
 from tqdm import tqdm
 
 from b2aiprep.prepare.constants import AUDIO_FILESTEMS_TO_REMOVE, PARTICIPANT_ID_TO_REMOVE
+from b2aiprep.prepare.prepare import reduce_id_length, reduce_length_of_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -129,6 +130,9 @@ def feature_extraction_generator(
 
         data = data[:, ::2]
         output[feature_name] = data
+
+        output["participant_id"] = reduce_id_length(output["participant_id"])
+        output["session_id"] = reduce_id_length(output["session_id"])
 
         yield output
 
@@ -299,5 +303,9 @@ def load_phenotype_data(base_path: Path, phenotype_name: str) -> t.Tuple[pd.Data
     # create columns missing in the original data
     if ("gender_identity" in df.columns) and ("specify_gender_identity" in df.columns):
         df, phenotype = _add_sex_at_birth_column(df, phenotype)
+
+    # reduce record_id to 8 characters
+    df = reduce_length_of_id(df, id_name='record_id')
+    df = reduce_length_of_id(df, id_name='session_id')
 
     return df, phenotype

--- a/src/b2aiprep/prepare/derived_data.py
+++ b/src/b2aiprep/prepare/derived_data.py
@@ -41,6 +41,9 @@ def spectrogram_generator(
         spectrogram = spectrogram[:, ::2]
         output["spectrogram"] = spectrogram
 
+        output["participant_id"] = reduce_id_length(output["participant_id"])
+        output["session_id"] = reduce_id_length(output["session_id"])
+
         yield output
 
 

--- a/src/b2aiprep/prepare/prepare.py
+++ b/src/b2aiprep/prepare/prepare.py
@@ -530,4 +530,14 @@ def filter_audio_paths(audio_paths: List[Path]) -> List[Path]:
         )
     
     return audio_paths
+
+def reduce_id_length(x):
+    return x.split('-')[0]
+
+def reduce_length_of_id(df: pd.DataFrame, id_name: str) -> pd.DataFrame:
+    """Reduce length of ID in the dataframe."""
+    for c in df.columns:
+        if c == id_name or c.endswith(id_name):
+            df[c] = df[c].apply(reduce_id_length)
     
+    return df

--- a/src/b2aiprep/prepare/prepare.py
+++ b/src/b2aiprep/prepare/prepare.py
@@ -544,3 +544,28 @@ def reduce_length_of_id(df: pd.DataFrame, id_name: str) -> pd.DataFrame:
             df[c] = df[c].apply(reduce_id_length)
     
     return df
+
+def get_value_from_metadata(metadata: dict, linkid: str, endswith: bool = False) -> str:
+    for item in metadata['item']:
+        if 'linkId' not in item:
+            continue
+        if item['linkId'] == linkid:
+            return item['answer'][0]['valueString']
+        if endswith and item['linkId'].endswith(linkid):
+            return item['answer'][0]['valueString']
+    return None
+
+def update_metadata_record_and_session_id(metadata: dict):
+    for item in metadata['item']:
+        if 'linkId' not in item:
+            continue
+
+        if item['linkId'] == 'record_id':
+            record_id = item['answer'][0]['valueString']
+            item['answer'][0]['valueString'] = reduce_id_length(record_id)
+            # rename to participant_id
+            item['linkId'] = 'participant_id'
+        elif (item['linkId'] == 'session_id') or (item['linkId'].endswith('_session_id')):
+            item['answer'][0]['valueString'] = reduce_id_length(
+                item['answer'][0]['valueString']
+            )

--- a/src/b2aiprep/prepare/prepare.py
+++ b/src/b2aiprep/prepare/prepare.py
@@ -532,6 +532,9 @@ def filter_audio_paths(audio_paths: List[Path]) -> List[Path]:
     return audio_paths
 
 def reduce_id_length(x):
+    """Reduce length of ID."""
+    if pd.isnull(x):
+        return x
     return x.split('-')[0]
 
 def reduce_length_of_id(df: pd.DataFrame, id_name: str) -> pd.DataFrame:

--- a/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/README.md
+++ b/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/README.md
@@ -5,13 +5,11 @@ This README provides an overview of the directory structure and the purpose of e
 ## Root Directory
 
 ### phenotype
-The phenotype directory stores participant-specific data that is not directly related to specific audio tasks but is relevant for understanding participants' characteristics.
+The phenotype directory stores participant-specific data that is not directly related to specific audio tasks but is relevant for understanding participants' characteristics. Primarily it contains responses to questionnaires by the individual.
 
 - **phenotype/<measurement_tool_name>.tsv**: A tab-separated values (TSV) file containing phenotype data collected using a specific measurement tool.
 
 - **phenotype/<measurement_tool_name>.json**: A JSON file that provides metadata or additional information about the phenotype data collected using a specific measurement tool.
-
-- **CHANGES**: A file that documents the changes, updates, and revisions made to the project over time.
 
 - **dataset_description.json**: A JSON file describing the dataset, including information such as the dataset's purpose, structure, and any relevant metadata.
 
@@ -25,26 +23,12 @@ Each participant has a directory named `sub-<participant_id>`, containing sessio
 
 ### Within `sub-<participant_id>`
 
-- **sessions.tsv**: A TSV file listing all sessions for the participant, including session IDs and other relevant details.
-
 ### Session-Specific Directories
 
 Each session directory is named `ses-<session_id>` and contains subdirectories for different types of data collected during that session.
 
 #### Voice Data
 
-- **voice/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_transcript.txt**: A text file containing the transcript of the audio recording for a specific task and run.
+- **audio/sub-<participant_id>_ses-<session_id>_task-<task_name>.json**: A JSON file containing metadata about the audio recording, including information such as recording identifiers, settings, and conditions.
 
-- **voice/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_metadata.json**: A JSON file containing metadata about the audio recording, including information such as recording settings and conditions.
-
-- **voice/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_features.pt**: A file containing extracted features from the audio recording, stored in a format suitable for further analysis.
-
-- **voice/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_audio.wav**: The raw audio recording file for a specific task and run.
-
-#### Behavioral Data
-
-- **beh/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_response.json**: A JSON file containing the participant's responses for a specific task and run.
-
-- **beh/sub-<participant_id>_ses-<session_id>_task-<task_name>_run-<index>_metadata.json**: A JSON file containing metadata about the behavioral data, including information such as task conditions and settings.
-
-This structure helps to organize and manage the data collected for each participant and session, ensuring that all relevant information is easily accessible and well-documented.
+- **audio/sub-<participant_id>_ses-<session_id>_task-<task_name>.wav**: The raw audio recording file for a specific task and run.

--- a/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/dataset_description.json
+++ b/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/dataset_description.json
@@ -1,5 +1,5 @@
 {
-    "BIDSVersion": "1.9.0",
+    "BIDSVersion": "2.0.0",
     "License": "LICENSE.txt",
-    "Name": "Bridge2AI-Voice: An ethically-sourced, diverse voice dataset linked to health information (Audio included)",
+    "Name": "Bridge2AI-Voice: An ethically-sourced, diverse voice dataset linked to health information (Audio included)"
 }

--- a/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/dataset_description.json
+++ b/src/b2aiprep/prepare/resources/b2ai-data-bids-like-template/dataset_description.json
@@ -1,5 +1,5 @@
 {
-    "BIDSVersion": "2.0.0",
+    "BIDSVersion": "1.9.0",
     "License": "LICENSE.txt",
     "Name": "Bridge2AI-Voice: An ethically-sourced, diverse voice dataset linked to health information (Audio included)"
 }


### PR DESCRIPTION
Small fixes to enable publishing v2.0.0

- trimmed participant ID and session ID to 8 characters as publishing platform only supports files up to 100 characters
    - and honestly having filenames > 100 characters and participant IDs > 32 characters is pretty tedious anyway
    - this has a 1% chance of a conflict once we hit 10,000 participants so the code will need updating before then
-  fixes the participant ID removal to apply to all derived/published datasets, before it missed the derived dataset
- clean up the README and data description
- copy over the fixed resources from this repo (readme, data description, changelog) to the published dataset within the publish command