### PR TITLE
Fix torchaudio versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,9 @@ dependencies = [
     "streamlit>=1.42.2",
     "av~=14.1.0",
     "soundfile",
-    "torchaudio~=2.8.0"
+    "torchaudio~=2.8.0",
+    "torch~=2.8.0",
+    "torchvision~=0.23.0"
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Torchaudio 2.9 introduces breaking changes to downstream packages so forcing it to remain as 2.8.