### PR TITLE
Added github actions workflow to address submodule issues

### DIFF
--- a/.github/workflows/pipeline_trigger.yml
+++ b/.github/workflows/pipeline_trigger.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           app-id: ${{ vars.BRIDGE_APP_ID }}
           private-key: ${{ secrets.BRIDGE_APP_PRIVATE_KEY }}
-          owner: Evan8456 
+          owner: sensein 
           repositories: b2aiprep
 
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
 
       - name: Get redcap2rs files
         run: |
-          git clone --depth 1 https://${{ steps.app-token.outputs.token }}@github.com/Evan8456/b2ai-redcap2rs
+          git clone --depth 1 https://${{ steps.app-token.outputs.token }}@github.com/sensein/b2ai-redcap2rs
           mkdir -p src/b2aiprep/redcap2rs
           cp -r b2ai-redcap2rs/* src/b2aiprep/redcap2rs
 
@@ -65,7 +65,7 @@ jobs:
           curl -X POST \
             -H "Authorization: Bearer ${{ steps.app-token.outputs.token }}" \
             -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/Evan8456/b2aiprep/pulls \
+            https://api.github.com/repos/sensein/b2aiprep/pulls \
             -d '{
                   "title": "Update files for '"$BRANCH_NAME"'",
                   "head": "'"$BRANCH_NAME"'",


### PR DESCRIPTION
- Added a actions workflow that gets triggered when redcap2rs repo is updated. Creates a branch and adds the new reproschema files into the package. 
- Will require a github actions secret for it to work