### PR TITLE
fix(audio-task-descriptions): correct ordering, content, and missing …

### DIFF
--- a/src/b2aiprep/prepare/resources/audio_task_descriptions.json
+++ b/src/b2aiprep/prepare/resources/audio_task_descriptions.json
@@ -4396,7 +4396,7 @@
         "prompts": []
     },
     "random-item-generation": {
-        "instructions": "Say as many letters or numbers (0-9) as you can. You are allowed to repeat items. Your goal is to list as many as possible in a random order. Time limit 1 minutes. The selection will appear when you start recording. The recording will automatically stop at the end.",
+        "instructions": "Say as many letters or numbers (0-9) as you can. You are allowed to repeat items. Your goal is to list as many as possible in a random order. Time limit 2 minutes. The selection will appear when you start recording. The recording will automatically stop at the end.",
         "prompts": []
     },
     "breath-sounds": {
@@ -4404,7 +4404,7 @@
         "prompts": []
     },
     "cinderella-story": {
-        "instructions": "For this task, you will given a moment of view sequential pictures of the Cinderella story. When you are ready to record, please narrate the story to the best of your ability. Stop recording when you are finished.",
+        "instructions": "You'll receive a hard copy of the Cinderella storybook from our study team to refresh your memory of the story. When ready, click the 'Record' button below to begin narrating the story. Once you've finished, tap on 'Stop Recording'.",
         "prompts": []
     },
     "diadochokinesis-(v2)-puhtuhkuh": {
@@ -4431,6 +4431,10 @@
         "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'puh' as quickly and consistently as possible until the timer runs out - 'puhpuhpuhpuhpuhpuh'",
         "prompts": []
     },
+    "diadochokinesis-Pataka": {
+        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllables 'pataka' as quickly and consistently as possible until the timer runs out - 'patakapataka'",
+        "prompts": []
+    },
     "diadochokinesis-PA": {
         "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'pa' as quickly and consistently as possible until the timer runs out - 'papapapapapa'",
         "prompts": []
@@ -4443,12 +4447,8 @@
         "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllable 'ta' as quickly and consistently as possible until the timer runs out - 'tatatatatata'",
         "prompts": []
     },
-    "diadochokinesis-Pataka": {
-        "instructions": "This task helps us analyze the ease and precision of speech sound productions. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the syllables 'pataka' as quickly and consistently as possible until the timer runs out - 'patakapataka'",
-        "prompts": []
-    },
     "prolonged-Vowel": {
-        "instructions": "This task helps us analyze features in your voice: Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the sentence “1, 2, 3 aah” in your normal voice. Please hold the sound “aah” until the timer runs out.",
+        "instructions": "This task helps us analyze features in your voice. Please press the play button to listen to the demonstration on how to complete the task. Then, tap the record button and imitate the speaker by repeating the sentence “1, 2, 3 aah” in your normal voice. Please hold the sound “aah” until the timer runs out.",
         "prompts": []
     },
     "productive-Vocabulary": {
@@ -4487,18 +4487,6 @@
             "Please do not cover your mouth or place your hand between your mouth and the microphone during recording. Breathe normally, then when you are ready, tap the record button below and cough HARD as if something were stuck in your throat. Tap stop when finished."
         ]
     },
-    "respiration-and-cough-(v2)-threebreaths": {
-        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
-        "prompts": [
-            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
-        ]
-    },
-    "respiration-and-cough-threequickbreaths": {
-        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
-        "prompts": [
-            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
-        ]
-    },
     "respiration-and-cough-(v2)-threebreathsmouth": {
         "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
         "prompts": [
@@ -4509,6 +4497,18 @@
         "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
         "prompts": [
             "After pressing on record, take 3 deep breaths in and out through your nose with your mouth closed. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-(v2)-threebreaths": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
+        ]
+    },
+    "respiration-and-cough-threequickbreaths": {
+        "instructions": "Breathing sounds can also provide information on your health. Let's record them.",
+        "prompts": [
+            "After pressing on record, exhale normally, then inhale quickly through your mouth, as if you are trying to catch your breath. Record 3 of these breaths in a single recording. Tap stop when finished."
         ]
     },
     "respiration-and-cough-breath": {
@@ -4530,9 +4530,9 @@
         ]
     },
     "rainbow": {
-        "instructions": "For this task, you will tap the record button and read the following passage on the screen using your normal voice. When done, tap the record button again to stop.",
+        "instructions": "This task helps us evaluate how you use breathing to support your voice. Please read the following passage out loud in your typical voice.",
         "prompts": [
-            "When the sunlight strikes raindrops in the air, they act as a prism and form a rainbow. The rainbow is a division of white light into many beautiful colors. These take the shape of a long round arch, with its path high above, and its two ends apparently beyond the horizon. There is , according to legend, a boiling pot of gold at one end. People look, but no one ever finds it. When a man looks for something beyond his reach, his friends say he is looking for the pot of gold at the end of the rainbow. Throughout the centuries people have explained the rainbow in various ways. Some have accepted it as a miracle without physical explanation. To the Hebrews it was a token that there would be no more universal floods. The Greeks used to imagine that it was a sign from the gods to foretell war or heavy rain. The Norsemen considered the rainbow as a bridge over which the gods passed from earth to their home in the sky. Others have tried to explain the phenomenon physically. Aristotle thought that the rainbow was caused by reflection of the sun's rays by the rain. Since then physicists have found that it is not reflection, but refraction by the raindrops which causes the rainbows. Many complicated ideas about the rainbow have been formed. The difference in the rainbow depends considerably upon the size of the drops, and the width of the colored band increases as the size of the drops increases. The actual primary rainbow observed is said to be the effect of super-imposition of a number of bows. If the red of the second bow falls upon the green of the first, the result is to give a bow with an abnormally wide yellow band, since red and green light when mixed form yellow. This is a very common type of bow, one showing mainly red and yellow, with little or no green or blue."
+            "When the sunlight strikes raindrops in the air, they act as a prism and form a rainbow. The rainbow is a division of white light into many beautiful colors. These take the shape of a long round arch, with its path high above, and its two ends apparently beyond the horizon. There is, according to legend, a boiling pot of gold at one end."
         ]
     },
     "123s": {
@@ -4616,17 +4616,17 @@
     "caterpillar-passage": {
         "instructions": "This is a passage that contains speech sounds in English by sound frequency to test your ability to produce speech sounds. Please read the following passage out loud in your typical voice.",
         "prompts": [
-            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, 'There's no turning back now.'' People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
+            "Do you like amusement parks? Well, I sure do. To amuse myself, I went twice last spring. My most MEMORABLE moment was riding on the Caterpillar, which is a gigantic rollercoaster high above the ground. When I saw how high the Caterpillar rose into the bright blue sky I knew it was for me. After waiting in line for thirty minutes, I made it to the front where the man measured my height to see if I was tall enough. I gave the man my coins, asked for change, and jumped on the cart. Tick, tick, tick, the Caterpillar climbed slowly up the tracks. It went SO high I could see the parking lot. Boy was I SCARED! I thought to myself, 'There's no turning back now.' People were so scared they screamed as we swiftly zoomed fast, fast, and faster along the tracks. As quickly as it started, the Caterpillar came to a stop. Unfortunately, it was time to pack the car and drive home. That night I dreamt of the wild ride on the Caterpillar. Taking a trip to the amusement park and riding on the Caterpillar was my MOST memorable moment ever!"
         ]
     },
     "story-recall": {
-        "instructions": "Below you will be presented with a story about a boy and a frog. You may click forward to see the next image in the series. Feel free to move back and forth as much as you like until you are comfortable with the story. You will have up to 5 minutes to view the story, but you are not required to use the full 5 minutes. Once the time is up, please retell the story in as much detail as possible. When you are ready, please click the record button below.",
+        "instructions": "Below you will be presented with a story about a boy and a frog. You may click forward to see the next image in the series. Feel free to move back and forth as much as you like until you are comfortable with the story. You will have up to 5 minutes to view the story, but you are not required to use the full 5 minutes. Once the time is up, please retell the story in as much detail as possible. When you are ready, please click the record button below. Once you click the record button, the story will disappear.",
         "prompts": [
             "There was once a boy who had a dog and a pet frog. He kept the frog in a large jar in his bedroom. One night while he and his dog were sleeping, the frog climbed out of the jar. He jumped out of an open window. When the boy and the dog woke up the next morning, they saw that the jar was empty. The boy looked everywhere for the frog. The dog looked for the frog too. When the dog tried to look in the jar, he got his head stuck. he boy and the dog looked outside for the frog. The boy called out, “Frog, where are you? ”The boy climbed up on a rock and called again for his frog. He held onto some branches so he wouldn't fall. But the branches weren't really branches! They were deer antlers. The deer picked the boy up on his head and started running. The deer stopped suddenly and the boy and the dog fell over the edge of a cliff. There was a pond below the cliff. They landed with a splash right on top of one another. They heard a familiar sound. They crept up and looked behind a big log. There they found the boy's pet frog, with a mother frog and other baby frogs. The end."
         ]
     },
     "word-color-stroop": {
-        "instructions": "Tap on the red circle below to start recording. The recording will continue through all tasks and automatically stop at the end.",
+        "instructions": "This exercise asks you to name out loud the color in which a word is displayed. Sometimes the word will be a color word: do not read the word aloud, just state the color in which it's displayed. For example, if you see the word \"brown\", and its letters are displayed in blue, you will say the word \"blue\". Please answer as quickly as possible. Time limit = 5 seconds/item, 15 random words. Total time 75s. Tap on the red circle below to start recording. The recording will continue through all tasks and automatically stop at the end.",
         "prompts": [
             "red",
             "green",
@@ -4634,6 +4634,58 @@
             "brown",
             "purple",
             "oooo"
+        ]
+    },
+    "free-speech-(v2)-1": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "What is your favorite season (winter, fall, summer, or spring) and why? Talk about the food, clothing, and activities you enjoy at that time."
+        ]
+    },
+    "free-speech-(v2)-2": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "Thinking back over the past 2 weeks, describe your general mood, either positive or negative. What things have contributed to you feeling this way?"
+        ]
+    },
+    "free-speech-(v2)-3": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. We'd like to get a recording of your natural speech. Please answer the following questions as though you were having a conversation. We'll record about 30 seconds of your response.",
+        "prompts": [
+            "Tell us about your favorite book or movie. Why do you like it?"
+        ]
+    },
+    "free-speech-1": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "Can you talk to us about why you are interested by this study? Who told you about it? Why is it meaningful or valuable to you? How do you think it will help patients in the future?"
+        ]
+    },
+    "free-speech-2": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "If you are enrolled due to a health condition, can you tell us about it? When did it start, what kind of symptoms have you had and for how long? Tell us how you are managing it and how you are doing? If you are healthy and don't have any health conditions, please tell us about how you stay healthy."
+        ]
+    },
+    "free-speech-3": {
+        "instructions": "This section is meant to hear you speak freely by answering an open-ended question. Please answer the following questions and record your answer. Keep talking until the time stops.",
+        "prompts": [
+            "Can you tell us about your mood in the past couple of weeks? What makes you feel happiness and what makes you feel sadness or stress?"
+        ]
+    },
+    "free-speech": {
+        "instructions": "Please answer the following question. You can read the question, then click on the recording button when you are ready to answer. You can keep talking until the timer is up.",
+        "prompts": [
+            "Can you explain your voice/speech problems and why you consulted a physician for them?"
+        ]
+    },
+    "voluntary-cough": {
+        "instructions": "You are being asked to record coughing sounds. Breathe normally, then when you are ready, push record and cough HARD as if something were stuck in your throat. Then breathe normally again. Complete this task 3 times in a single recording.",
+        "prompts": []
+    },
+    "open-response-questions": {
+        "instructions": "Please answer the following questions and record your answer.",
+        "prompts": [
+            "Think of a single issue, feeling, emotion or symptom you have been experiencing lately. For example, sadness, fatigue, anxiety, loneliness, sleep issues, concentration issues, agitation, motivation, numbness, guilt, shame. If you are not experiencing anything negative, think of a positive one such as calmness or gratitude. Then describe how it shows up for you mentally and physically, what you see as its causes, and what situations trigger it."
         ]
     },
     "naming-animals": {


### PR DESCRIPTION
  ## Summary
  - **Ordering fixes**: moved `diadochokinesis-Pataka` before `diadochokinesis-PA`, and respiration v2 `threebreathsmouth`/`threebreathsnose` before `threebreaths` — the
  first-match-wins substring lookup was routing these tasks to the wrong instructions
  - **Content fixes**: `random-item-generation` time limit (1→2 min), `cinderella-story` instructions, `prolonged-Vowel` punctuation, `rainbow` prompt shortened to first
  paragraph only, `story-recall` missing note about story disappearing, `word-color-stroop` full task explanation, `caterpillar-passage` stray apostrophe
  - **Missing keys added**: `free-speech-1/2/3`, `free-speech-(v2)-1/2/3`, bare `free-speech`, `voluntary-cough`, `open-response-questions` — these tasks had no match at all in
   the lookup 
   
  ## Test plan
  - [ ] Verify task lookup simulation passes (0 unmatched tasks across adult + peds datasets)
  - [ ] Spot-check content for amended keys against `bridge2ai-redcap` docs
  - [ ] Confirm `diadochokinesis-Pataka` and respiration mouth/nose tasks no longer get generic instructions
  
  🤖 Generated with [Claude Code](https://claude.com/claude-code)