### PR TITLE
Updates for internal releasing 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -122,6 +122,18 @@ sensitive information, referred to as deidentification. Deidentification require
 - `audio_tasks_to_include.json` (File containing list of audio tasks to include during deidentification)
 
 Create these files and place them in a folder, e.g. `deidentification_config` (the "config" folder).
+
+#### (Optional) Generate or extend `id_remapping.json`
+
+When preparing a new release, the participant list often contains IDs that aren't yet in the existing `id_remapping.json`. To bootstrap the file from scratch — or to add fresh pseudonyms for any new IDs while preserving the mappings already in use — run:
+
+```sh
+b2aiprep-cli generate-id-lookup-table <path/to/ids_file> <path/to/output/dir> \
+    --load_lookup <path/to/existing/id_remapping.json>
+```
+
+The input file may be the original RedCap export (`.csv`) from step 1 or the BIDS `participants.tsv` produced in step 2 — either works, as long as it has a `record_id` or `participant_id` column. The command writes `id_lookup_table.json` to the output directory; entries from `--load_lookup` are kept verbatim, and only new IDs get new pseudonyms. Drop the `--load_lookup` flag when generating the very first lookup table for a release. Rename the resulting file to `id_remapping.json` (or copy it) and place it in your deidentification config folder before continuing.
+
 After creating these files, you can run the deidentify dataset command:
 
 ```

--- a/src/b2aiprep/cli.py
+++ b/src/b2aiprep/cli.py
@@ -21,7 +21,7 @@ from b2aiprep.commands import (  # gensynthtabdata,
     deidentify_bids_dataset,
     run_quality_control_on_audios,
     update_bids_template_command,
-    id_remap,
+    generate_id_lookup_table,
     create_subject_splits,
 )
 
@@ -64,7 +64,7 @@ cli.add_command(bids2shadow)
 cli.add_command(validate_feature_extraction)
 cli.add_command(run_quality_control_on_audios)
 cli.add_command(update_bids_template_command)
-cli.add_command(id_remap)
+cli.add_command(generate_id_lookup_table)
 cli.add_command(create_subject_splits)
 
 if __name__ == "__main__":

--- a/src/b2aiprep/cli.py
+++ b/src/b2aiprep/cli.py
@@ -22,6 +22,7 @@ from b2aiprep.commands import (  # gensynthtabdata,
     run_quality_control_on_audios,
     update_bids_template_command,
     id_remap,
+    create_subject_splits,
 )
 
 
@@ -64,6 +65,7 @@ cli.add_command(validate_feature_extraction)
 cli.add_command(run_quality_control_on_audios)
 cli.add_command(update_bids_template_command)
 cli.add_command(id_remap)
+cli.add_command(create_subject_splits)
 
 if __name__ == "__main__":
     # include main to enable python debugging

--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -1551,11 +1551,11 @@ def create_subject_splits(input_file, output_dir, id_column, num_participants_pe
 @click.argument("input_file", type=click.Path(exists=True))
 @click.argument("output_dir", type=click.Path())
 @click.option("--load_lookup", type=click.Path(exists=True), default=None, show_default=True)
-def id_remap(input_file, output_dir, load_lookup):
+def generate_id_lookup_table(input_file, output_dir, load_lookup):
     """Generates an id lookup table for dissemination.
 
     Args:
-        input_dir (path): Path to file with original ids
+        input_file (path): Path to file with original ids
         output_dir (path): Path to output folder
         load_lookup (path): Path to pre-existing id remap file
     """

--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -1500,6 +1500,53 @@ def redcap_stats(filename, num_sessions):
             for record_id, n_sessions in over_n_sessions.items():
                 click.echo(f"Record ID: {record_id}, Sessions: {n_sessions}")
 
+
+@click.command()
+@click.argument("input_file", type=click.Path(exists=True))
+@click.argument("output_dir", type=click.Path())
+@click.option("--id_column", type=str, default="record_id", show_default=True)
+@click.option("--num_participants_per_file", type=int, default=10, show_default=True)
+def create_subject_splits(input_file, output_dir, id_column, num_participants_per_file):
+    """Split unique participant IDs from a TSV into multiple subject-id list files.
+
+    Reads ``input_file`` (a TSV with one row per record), extracts unique values from
+    ``id_column``, and writes them in sorted order across ``subject_ids_<i>.txt`` files
+    under ``output_dir``, one ID per line, with at most ``num_participants_per_file`` IDs
+    per file.
+
+    Args:
+        input_file (path): Path to TSV file containing participant IDs.
+        output_dir (path): Path to output folder (created if it does not exist).
+        id_column (str): Column in the input file representing IDs to split.
+        num_participants_per_file (int): Maximum number of unique participant IDs per output file.
+
+    Returns: None
+    Effects: Writes ``subject_ids_0.txt``, ``subject_ids_1.txt``, ... under ``output_dir``.
+    """
+    if num_participants_per_file < 1:
+        raise click.UsageError("--num_participants_per_file must be >= 1.")
+
+    df = pd.read_csv(input_file, sep="\t")
+    if id_column not in df.columns:
+        raise click.UsageError(
+            f"Column '{id_column}' not found in {input_file}. "
+            f"Available columns: {list(df.columns)}"
+        )
+
+    id_list = sorted({str(x) for x in df[id_column].dropna().tolist()})
+    if not id_list:
+        raise click.UsageError(f"No IDs found in column '{id_column}'.")
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for idx, start in enumerate(range(0, len(id_list), num_participants_per_file)):
+        chunk = id_list[start : start + num_participants_per_file]
+        out_file = output_dir / f"subject_ids_{idx}.txt"
+        out_file.write_text("\n".join(chunk) + "\n")
+        _LOGGER.info(f"Wrote {len(chunk)} IDs to '{out_file}'")
+
+
 @click.command()
 @click.argument("input_file", type=click.Path(exists=True))
 @click.argument("output_dir", type=click.Path())

--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -1507,15 +1507,17 @@ def redcap_stats(filename, num_sessions):
 @click.option("--id_column", type=str, default="record_id", show_default=True)
 @click.option("--num_participants_per_file", type=int, default=10, show_default=True)
 def create_subject_splits(input_file, output_dir, id_column, num_participants_per_file):
-    """Split unique participant IDs from a TSV into multiple subject-id list files.
+    """Split unique participant IDs into multiple subject-id list files.
 
-    Reads ``input_file`` (a TSV with one row per record), extracts unique values from
-    ``id_column``, and writes them in sorted order across ``subject_ids_<i>.txt`` files
-    under ``output_dir``, one ID per line, with at most ``num_participants_per_file`` IDs
-    per file.
+    Reads ``input_file`` (one row per record), extracts unique values from ``id_column``,
+    and writes them in sorted order across ``subject_ids_<i>.txt`` files under
+    ``output_dir``, one ID per line, with at most ``num_participants_per_file`` IDs per
+    file.
 
     Args:
-        input_file (path): Path to TSV file containing participant IDs.
+        input_file (path): Path to a file containing participant IDs. May be a
+            comma-separated ``.csv`` (e.g. a RedCap export) or a tab-separated file such
+            as ``participants.tsv``; the delimiter is selected from the file extension.
         output_dir (path): Path to output folder (created if it does not exist).
         id_column (str): Column in the input file representing IDs to split.
         num_participants_per_file (int): Maximum number of unique participant IDs per output file.
@@ -1526,7 +1528,8 @@ def create_subject_splits(input_file, output_dir, id_column, num_participants_pe
     if num_participants_per_file < 1:
         raise click.UsageError("--num_participants_per_file must be >= 1.")
 
-    df = pd.read_csv(input_file, sep="\t")
+    sep = "," if str(input_file).lower().endswith(".csv") else "\t"
+    df = pd.read_csv(input_file, sep=sep)
     if id_column not in df.columns:
         raise click.UsageError(
             f"Column '{id_column}' not found in {input_file}. "

--- a/src/b2aiprep/commands.py
+++ b/src/b2aiprep/commands.py
@@ -1555,11 +1555,14 @@ def generate_id_lookup_table(input_file, output_dir, load_lookup):
     """Generates an id lookup table for dissemination.
 
     Args:
-        input_file (path): Path to file with original ids
+        input_file (path): Path to file with original ids. May be a comma-separated ``.csv``
+            (e.g. a RedCap export) or a tab-separated file such as ``participants.tsv``;
+            the delimiter is selected from the file extension.
         output_dir (path): Path to output folder
         load_lookup (path): Path to pre-existing id remap file
     """
-    df = pd.read_csv(input_file, sep='\t')
+    sep = "," if str(input_file).lower().endswith(".csv") else "\t"
+    df = pd.read_csv(input_file, sep=sep)
     
     id_column = ""
     if "record_id" in df.columns:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -889,20 +889,20 @@ def test_reproschema_to_redcap_cli():
 
 
 
-def test_id_remap_cli():
-    """Test the 'b2aiprep-cli id-remap command using subprocess."""
+def test_generate_id_lookup_table_cli():
+    """Test the 'b2aiprep-cli generate-id-lookup-table' command using subprocess."""
     with tempfile.TemporaryDirectory() as temp_dir:
         ids = {"participant_id": ["P001", "P002"]}
         id_df = pd.DataFrame(ids)
         id_dir = Path(temp_dir) / "ids.tsv"
-        
+
         id_df.to_csv(id_dir, sep='\t', index=False)
 
         output_dir = Path(temp_dir) / "output"
         output_dir.mkdir(parents=True, exist_ok=True)
         command = [
             "b2aiprep-cli",
-            "id-remap",
+            "generate-id-lookup-table",
             id_dir,
             output_dir
         ]
@@ -912,9 +912,9 @@ def test_id_remap_cli():
         assert result.returncode == 0, f"CLI command failed: {result.stderr}"
         assert output_dir.exists(), "Output directory was not created"
         assert output_file.exists(), "Output file was not created"
-        
-def test_id_remap_existing_remap_cli():
-    """Test the 'b2aiprep-cli id-remap command using subprocess."""
+
+def test_generate_id_lookup_table_existing_remap_cli():
+    """Test the 'b2aiprep-cli generate-id-lookup-table' command with --load_lookup."""
     with tempfile.TemporaryDirectory() as temp_dir:
         ids = {"participant_id": ["P001", "P002"]}
         id_df = pd.DataFrame(ids)
@@ -929,7 +929,7 @@ def test_id_remap_existing_remap_cli():
         output_dir.mkdir(parents=True, exist_ok=True)
         command = [
             "b2aiprep-cli",
-            "id-remap",
+            "generate-id-lookup-table",
             id_dir,
             output_dir,
             "--load_lookup",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,7 +16,7 @@ import shutil
 from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
 
-from b2aiprep.commands import deidentify_bids_dataset
+from b2aiprep.commands import create_subject_splits, deidentify_bids_dataset
 from b2aiprep.prepare.dataset import BIDSDataset
 
 class TestDeidentifyCommand:
@@ -951,4 +951,114 @@ def test_id_remap_existing_remap_cli():
         assert data["P004"] == "678910", "Remap is incorrect"
         assert "P001" in data, "P001 is missing in remap file"
         assert "P002" in data, "P002 is missing in remap file"
-        
+
+
+def _write_ids_tsv(path, ids, id_column="record_id"):
+    pd.DataFrame({id_column: ids}).to_csv(path, sep="\t", index=False)
+
+
+def _read_split_files(output_dir):
+    files = sorted(Path(output_dir).glob("subject_ids_*.txt"))
+    return [f.read_text().strip().splitlines() for f in files]
+
+
+class TestCreateSubjectSplits:
+    """Tests for the create_subject_splits command."""
+
+    def test_splits_default_chunk_size(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, [f"R{i:03d}" for i in range(25)])
+        output_dir = tmp_path / "out"
+
+        runner = CliRunner()
+        result = runner.invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code == 0, result.output
+
+        chunks = _read_split_files(output_dir)
+        assert [len(c) for c in chunks] == [10, 10, 5]
+        # Round-trip covers every unique ID exactly once.
+        flat = [x for chunk in chunks for x in chunk]
+        assert sorted(flat) == sorted({f"R{i:03d}" for i in range(25)})
+
+    def test_splits_exact_multiple(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, [f"R{i}" for i in range(20)])
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(
+            create_subject_splits,
+            [str(input_file), str(output_dir), "--num_participants_per_file", "5"],
+        )
+        assert result.exit_code == 0, result.output
+        chunks = _read_split_files(output_dir)
+        assert [len(c) for c in chunks] == [5, 5, 5, 5]
+
+    def test_single_participant_creates_one_file(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["only_one"])
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code == 0, result.output
+        chunks = _read_split_files(output_dir)
+        assert chunks == [["only_one"]]
+
+    def test_deduplicates_ids(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["A", "B", "A", "C", "B"])
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code == 0, result.output
+        chunks = _read_split_files(output_dir)
+        assert chunks == [["A", "B", "C"]]
+
+    def test_custom_id_column(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["P1", "P2", "P3"], id_column="participant_id")
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(
+            create_subject_splits,
+            [str(input_file), str(output_dir), "--id_column", "participant_id"],
+        )
+        assert result.exit_code == 0, result.output
+        chunks = _read_split_files(output_dir)
+        assert chunks == [["P1", "P2", "P3"]]
+
+    def test_creates_output_dir_when_missing(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["A"])
+        output_dir = tmp_path / "nested" / "not_yet_created"
+        assert not output_dir.exists()
+
+        result = CliRunner().invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code == 0, result.output
+        assert output_dir.is_dir()
+        assert (output_dir / "subject_ids_0.txt").exists()
+
+    def test_missing_id_column_errors(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["A"], id_column="participant_id")
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code != 0
+        assert "record_id" in result.output
+
+    def test_invalid_num_per_file_errors(self, tmp_path):
+        input_file = tmp_path / "ids.tsv"
+        _write_ids_tsv(input_file, ["A"])
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(
+            create_subject_splits,
+            [str(input_file), str(output_dir), "--num_participants_per_file", "0"],
+        )
+        assert result.exit_code != 0
+
+    def test_help_documents_options(self):
+        result = CliRunner().invoke(create_subject_splits, ["--help"])
+        assert result.exit_code == 0
+        assert "num_participants_per_file" in result.output
+        assert "id_column" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1013,6 +1013,16 @@ class TestCreateSubjectSplits:
         chunks = _read_split_files(output_dir)
         assert chunks == [["A", "B", "C"]]
 
+    def test_accepts_csv_input(self, tmp_path):
+        # RedCap exports are comma-separated; the command should dispatch on extension.
+        input_file = tmp_path / "redcap.csv"
+        pd.DataFrame({"record_id": ["A", "B", "C"]}).to_csv(input_file, index=False)
+        output_dir = tmp_path / "out"
+
+        result = CliRunner().invoke(create_subject_splits, [str(input_file), str(output_dir)])
+        assert result.exit_code == 0, result.output
+        assert _read_split_files(output_dir) == [["A", "B", "C"]]
+
     def test_custom_id_column(self, tmp_path):
         input_file = tmp_path / "ids.tsv"
         _write_ids_tsv(input_file, ["P1", "P2", "P3"], id_column="participant_id")


### PR DESCRIPTION
- Adds a command for creating subject splits, used for running feature generation more efficiently (could've added to external scripts but decided it doesn't hurt to have here)
- Renamed `id_remap` to match verb-based command naming
- Added remapping IDs to RELEASE.md