### PR TITLE
Add regression tests for PyPI install fixes

### DIFF
--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -966,3 +966,111 @@ def test_validate_bids_folder_complex_filenames():
 
             # Should log success message
             mock_logger.warning.assert_not_called()
+
+
+class _StopAfterDispatch(Exception):
+    """Sentinel raised by a stubbed _load_reproschema to halt after dispatch is observed."""
+
+    def __init__(self, folder):
+        super().__init__()
+        self.folder = folder
+
+
+def _construct_phenotype_dispatch_df():
+    return pd.DataFrame({
+        "record_id": ["r1"],
+        "redcap_repeat_instrument": ["Acoustic Task"],
+    })
+
+
+def test_construct_phenotype_locates_commit_sha_for_flat_layout(tmp_path, monkeypatch):
+    """Layout A: schema directly in redcap2rs/ → reproschema_folder = redcap2rs/."""
+    redcap2rs = tmp_path / "redcap2rs"
+    redcap2rs.mkdir()
+    (redcap2rs / "b2ai-redcap2rs_schema").write_text(json.dumps({"ui": {"order": []}}))
+
+    monkeypatch.setattr("b2aiprep.prepare.dataset.files", lambda _: redcap2rs)
+
+    def stub(_schema, folder):
+        raise _StopAfterDispatch(folder)
+
+    monkeypatch.setattr(BIDSDataset, "_load_reproschema", staticmethod(stub))
+
+    with pytest.raises(_StopAfterDispatch) as exc:
+        BIDSDataset._construct_phenotype_from_reproschema(
+            _construct_phenotype_dispatch_df(), output_dir=str(tmp_path / "out")
+        )
+
+    assert exc.value.folder == redcap2rs.resolve()
+
+
+def test_construct_phenotype_locates_commit_sha_for_nested_layout(tmp_path, monkeypatch):
+    """Layout B: schema nested in redcap2rs/b2ai-redcap2rs/ → reproschema_folder = redcap2rs/."""
+    redcap2rs = tmp_path / "redcap2rs"
+    nested = redcap2rs / "b2ai-redcap2rs"
+    nested.mkdir(parents=True)
+    (nested / "b2ai-redcap2rs_schema").write_text(json.dumps({"ui": {"order": []}}))
+
+    monkeypatch.setattr("b2aiprep.prepare.dataset.files", lambda _: redcap2rs)
+
+    def stub(_schema, folder):
+        raise _StopAfterDispatch(folder)
+
+    monkeypatch.setattr(BIDSDataset, "_load_reproschema", staticmethod(stub))
+
+    with pytest.raises(_StopAfterDispatch) as exc:
+        BIDSDataset._construct_phenotype_from_reproschema(
+            _construct_phenotype_dispatch_df(), output_dir=str(tmp_path / "out")
+        )
+
+    assert exc.value.folder == redcap2rs.resolve()
+
+
+def test_construct_phenotype_resolves_symlinked_install_path(tmp_path, monkeypatch):
+    """When files() returns a symlinked path, the folder passed downstream is the resolved one."""
+    real = tmp_path / "real" / "redcap2rs"
+    nested = real / "b2ai-redcap2rs"
+    nested.mkdir(parents=True)
+    (nested / "b2ai-redcap2rs_schema").write_text(json.dumps({"ui": {"order": []}}))
+
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    monkeypatch.setattr("b2aiprep.prepare.dataset.files", lambda _: link)
+
+    def stub(_schema, folder):
+        raise _StopAfterDispatch(folder)
+
+    monkeypatch.setattr(BIDSDataset, "_load_reproschema", staticmethod(stub))
+
+    with pytest.raises(_StopAfterDispatch) as exc:
+        BIDSDataset._construct_phenotype_from_reproschema(
+            _construct_phenotype_dispatch_df(), output_dir=str(tmp_path / "out")
+        )
+
+    assert exc.value.folder == real.resolve()
+    assert exc.value.folder != link
+
+
+def test_load_reproschema_resolves_paths_through_symlink(tmp_path):
+    """Activities reached via a symlink should not crash inside build_activity_payload."""
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "b2ai-redcap2rs_schema").write_text(
+        json.dumps({"ui": {"order": ["activities/test/test"]}})
+    )
+    activity_dir = real / "activities" / "test"
+    activity_dir.mkdir(parents=True)
+    (activity_dir / "test").write_text(json.dumps({"id": "test_id", "ui": {"order": []}}))
+    (real / "commit_sha.txt").write_text("abc12345")
+
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    schema_via_link = link / "b2ai-redcap2rs_schema"
+    folder_resolved = link.resolve()
+
+    result = BIDSDataset._load_reproschema(schema_via_link, folder_resolved)
+
+    assert "test_id" in result
+    assert "abc12345" in result["test_id"]["url"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import json
+import logging
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 import pandas as pd
@@ -7,6 +9,7 @@ import pytest
 
 from b2aiprep.prepare.utils import (
     copy_package_resource,
+    get_commit_sha,
     make_tsv_files,
     reformat_resources,
     remove_files_by_pattern,
@@ -87,6 +90,39 @@ def test_get_wav_duration():
     actual = get_wav_duration(b2ai_wav_path)
     expected  = 2.9257142857142857
     assert actual == expected
+
+
+def test_get_commit_sha_reads_file(tmp_path):
+    sha = "abcdef1234567890abcdef1234567890abcdef12"
+    (tmp_path / "commit_sha.txt").write_text(sha + "\n")
+    assert get_commit_sha(tmp_path) == sha
+
+
+def test_get_commit_sha_falls_back_to_git(tmp_path):
+    subprocess.run(["git", "-C", str(tmp_path), "init", "--quiet"], check=True)
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "config", "user.name", "test"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(tmp_path), "commit", "--quiet", "--allow-empty", "-m", "init"],
+        check=True,
+    )
+    expected = subprocess.run(
+        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert get_commit_sha(tmp_path) == expected
+
+
+def test_get_commit_sha_returns_empty_when_unrecoverable(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="b2aiprep.prepare.utils")
+    assert get_commit_sha(tmp_path) == ""
+    assert "Could not determine reproschema commit SHA" in caplog.text
+
 
 if __name__ == "__main__":
     pytest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -98,27 +98,32 @@ def test_get_commit_sha_reads_file(tmp_path):
     assert get_commit_sha(tmp_path) == sha
 
 
-def test_get_commit_sha_falls_back_to_git(tmp_path):
-    subprocess.run(["git", "-C", str(tmp_path), "init", "--quiet"], check=True)
-    subprocess.run(
-        ["git", "-C", str(tmp_path), "config", "user.email", "test@example.com"],
-        check=True,
-    )
-    subprocess.run(
-        ["git", "-C", str(tmp_path), "config", "user.name", "test"], check=True
-    )
-    subprocess.run(
-        ["git", "-C", str(tmp_path), "commit", "--quiet", "--allow-empty", "-m", "init"],
-        check=True,
-    )
-    expected = subprocess.run(
-        ["git", "-C", str(tmp_path), "rev-parse", "HEAD"],
-        capture_output=True, text=True, check=True,
-    ).stdout.strip()
-    assert get_commit_sha(tmp_path) == expected
+def test_get_commit_sha_falls_back_to_git(tmp_path, monkeypatch):
+    expected_sha = "a" * 40
+    captured = {}
+
+    def fake_run(cmd, capture_output, check, text):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout=expected_sha + "\n", stderr="")
+
+    monkeypatch.setattr("b2aiprep.prepare.utils.subprocess.run", fake_run)
+    assert get_commit_sha(tmp_path) == expected_sha
+    assert captured["cmd"] == ["git", "-C", str(tmp_path), "rev-parse", "HEAD"]
 
 
-def test_get_commit_sha_returns_empty_when_unrecoverable(tmp_path, caplog):
+@pytest.mark.parametrize(
+    "exc",
+    [
+        subprocess.CalledProcessError(128, ["git"]),
+        FileNotFoundError("git"),
+    ],
+    ids=["git_not_a_repo", "git_not_installed"],
+)
+def test_get_commit_sha_returns_empty_when_unrecoverable(tmp_path, monkeypatch, caplog, exc):
+    def fake_run(*args, **kwargs):
+        raise exc
+
+    monkeypatch.setattr("b2aiprep.prepare.utils.subprocess.run", fake_run)
     caplog.set_level(logging.WARNING, logger="b2aiprep.prepare.utils")
     assert get_commit_sha(tmp_path) == ""
     assert "Could not determine reproschema commit SHA" in caplog.text


### PR DESCRIPTION
Cover the failure modes that PR #310 fixed but that weren't exercised by the existing test suite (which only ran the happy path against the source tree's Layout B install with no symlink and a valid git repo).

tests/test_utils.py - get_commit_sha fallback chain:
- reads commit_sha.txt when present
- falls back to `git rev-parse HEAD` when the file is missing
- returns empty string with a warning when neither is available (this is the regression for the original PyPI crash)

tests/test_bids.py - _construct_phenotype_from_reproschema dispatch and _load_reproschema symlink handling:
- Layout A (schema directly in redcap2rs/) dispatches with the reproschema_folder set to redcap2rs/, not its parent (regression for the latent bug where parents[1] landed one directory too high)
- Layout B (schema nested in redcap2rs/b2ai-redcap2rs/) keeps the current behavior
- When importlib.resources.files() returns a symlinked path, the folder dispatched downstream is the resolved one (regression for the relative_to ValueError seen in conda envs with symlinked install prefixes)
- _load_reproschema processes activities reached via a symlinked path without raising inside build_activity_payload