### PR TITLE
Fix two feature data dictionaries; add opt-in strict verify; commit prepare_doi.py and verify_c2m2.py

### DIFF
--- a/external_scripts/c2m2/README.md
+++ b/external_scripts/c2m2/README.md
@@ -124,11 +124,53 @@ cfde-c2m2 prepare
 cfde-c2m2 validate
 ```
 
-Fix any validation errors, then package:
+`cfde-c2m2 validate` covers the schema and frictionless referential checks. Run
+`verify_c2m2.py` as well for the data-level checks it does not do — that every file row carries a
+checksum, that primary keys are unique, that `file_describes_biosample` has no orphans on either
+side, that no crosswalk or id-map file ended up inside the package, and that no Synapse ids appear
+in the tables (the disease firewall):
+
+```
+python verify_c2m2.py --package /path/to/c2m2_output
+```
+
+It exits non-zero on any hard failure and prints warnings for the rest. Fix everything both tools
+report, then package:
 
 ```
 cfde-c2m2 package -o /output/path/for/zip/2026_03_C2M2.zip
 ```
+
+## Versioning the citation DOI
+
+The controlled-access step reads md5 and size from the **citation-versioned** Synapse fileviews
+(`synapse_manifest.py`), so each release needs its own snapshot of those views with its own DOI. A
+new-version DOI must carry over the existing metadata — the long creator list, title, publisher,
+resourceType — and change only the version, so `prepare_doi.py` clones the existing DOI rather than
+building one from scratch.
+
+It is deliberately two-step and review-gated. Prepare is read-only and mints nothing:
+
+```
+# 1. Create the snapshot of the view in Synapse first, then prepare a payload for it
+python prepare_doi.py --view <viewSynId> --to-version <snapshotVersion>
+
+# 2. Review (and if needed edit) prepared_doi.json, then mint
+python prepare_doi.py --submit --payload prepared_doi.json
+```
+
+Notes worth knowing before you run it:
+
+- Auth comes from `SAGE_PAT` or `SYNAPSE_PAT`, else `~/.synapseConfig`.
+- The snapshot version must already exist; prepare refuses a version the entity does not have.
+- Server-assigned and old-DOI identity fields are stripped, so the new DOI is not a partial copy of
+  the old one's identity.
+- Synapse mangles non-ASCII creator names on GET, so names come back containing `?`. Pass
+  `--names-from-doi <existing DataCite DOI>` to source correctly encoded names from DataCite and
+  replace the mangled ones by position; it aborts rather than guess if the two orderings disagree.
+- **PII screening must happen before a snapshot is taken**, not after. A file deleted later is
+  removed from Synapse but its metadata (name, md5, path) remains in any DOI'd snapshot that already
+  included it — see the note in `../sage_upload_scripts/README.md`.
 
 # Post Metadata Generation
 

--- a/external_scripts/c2m2/prepare_doi.py
+++ b/external_scripts/c2m2/prepare_doi.py
@@ -1,0 +1,202 @@
+"""Prepare (and, separately, submit) a new-version DOI for a Synapse entity by
+cloning the metadata of its existing DOI -- so the long author/creator list,
+title, resourceType, etc. carry over and only the version changes.
+
+Two-step, review-gated workflow:
+
+  1) PREPARE (read-only; default):
+       python prepare_doi.py --view syn74341293 --to-version 2
+     Fetches the existing DOI (current, or --from-version N), bumps objectVersion
+     to the already-created snapshot version, strips server/identity fields, writes
+     the payload to --out (default prepared_doi.json), and prints a summary. Nothing
+     is minted. Review (and optionally edit) the JSON.
+
+  2) SUBMIT (mints the DOI; must point at the reviewed file):
+       python prepare_doi.py --submit --payload prepared_doi.json
+
+Auth: SAGE_PAT or SYNAPSE_PAT in the environment, else ~/.synapseConfig.
+"""
+import os
+import sys
+import json
+import time
+import argparse
+import urllib.request
+
+import synapseclient
+
+# Server-assigned / old-DOI-identity fields -- never copy these into the new DOI.
+_STRIP = {"associationId", "associatedBy", "associatedOn", "etag", "doiUri", "doiUrl",
+          "doiId", "createdBy", "createdOn", "updatedBy", "updatedOn"}
+
+
+def login():
+    syn = synapseclient.Synapse()
+    tok = os.environ.get("SAGE_PAT") or os.environ.get("SYNAPSE_PAT")
+    syn.login(authToken=tok) if tok else syn.login()
+    print(f"LOGIN OK as {syn.getUserProfile().get('userName')}", file=sys.stderr)
+    return syn
+
+
+def fetch_existing_doi(syn, view, from_version):
+    # NOTE: the GET /doi query param for the version is `version` (the Doi *object*
+    # field is `objectVersion`). A version-pinned DOI is invisible without it.
+    q = f"/doi?id={view}&type=ENTITY"
+    if from_version is not None:
+        q += f"&version={from_version}"
+    return syn.restGET(q)
+
+
+def entity_versions(syn, view):
+    try:
+        return {v["versionNumber"] for v in syn.restGET(f"/entity/{view}/version")["results"]}
+    except Exception:
+        return set()
+
+
+def build_new_payload(existing, to_version):
+    doi = {k: v for k, v in existing.items() if k not in _STRIP}
+    doi["objectVersion"] = to_version
+    doi.setdefault("concreteType", "org.sagebionetworks.repo.model.doi.v2.Doi")
+    return doi
+
+
+def fetch_datacite_creators(doi):
+    """Creator names from a DataCite record (correct UTF-8; Synapse GET mangles them)."""
+    with urllib.request.urlopen(f"https://api.datacite.org/dois/{doi}", timeout=30) as r:
+        data = json.load(r)
+    return [c.get("name") for c in data["data"]["attributes"].get("creators", [])]
+
+
+def apply_datacite_names(payload, dc_names):
+    """Replace the (Synapse-mangled) creatorNames containing '?' with the correctly
+    encoded DataCite names, matched by position. Aborts if the two lists don't line
+    up (length, or any ASCII name disagrees -> different ordering). Returns the
+    (old, new) pairs that were corrected."""
+    cr = payload.get("creators", [])
+    if len(cr) != len(dc_names):
+        raise SystemExit(f"creator-count mismatch: payload {len(cr)} vs DataCite {len(dc_names)} "
+                         "-- cannot align by position.")
+    # Compare trimmed: whitespace-only differences (stray trailing spaces exist in
+    # the stored names) are not real misalignments.
+    mism = [(i, cr[i]["creatorName"], dc_names[i]) for i in range(len(cr))
+            if "?" not in cr[i]["creatorName"]
+            and cr[i]["creatorName"].strip() != (dc_names[i] or "").strip()]
+    if mism:
+        raise SystemExit(f"DataCite/Synapse creator order disagrees on {len(mism)} ASCII name(s) "
+                         f"(e.g. {mism[:2]}); refusing to remap.")
+    fixed = []
+    for i, c in enumerate(cr):
+        if "?" in c["creatorName"]:
+            fixed.append((c["creatorName"], dc_names[i]))
+            c["creatorName"] = dc_names[i]
+    return fixed
+
+
+def _title(doi):
+    if doi.get("title"):
+        return doi["title"]
+    t = doi.get("titles")
+    if t:
+        return t[0].get("title") if isinstance(t[0], dict) else t[0]
+    return None
+
+
+def summarize(doi, existing):
+    creators = doi.get("creators", [])
+    print("\n================ PREPARED DOI (REVIEW) ================")
+    print(f"  objectId        : {doi.get('objectId')}")
+    print(f"  objectType      : {doi.get('objectType')}")
+    print(f"  objectVersion   : {existing.get('objectVersion')}  ->  {doi.get('objectVersion')}")
+    print(f"  title           : {_title(doi)}")
+    print(f"  publisher       : {doi.get('publisher')}")
+    print(f"  publicationYear : {doi.get('publicationYear')}")
+    print(f"  resourceType    : {doi.get('resourceType')}")
+    print(f"  creators        : {len(creators)} carried over")
+    if creators:
+        show = [c.get("creatorName", c) for c in creators[:3]]
+        print(f"      e.g. {show}{' ...' if len(creators) > 3 else ''}")
+    other = sorted(set(doi) - {"objectId", "objectType", "objectVersion", "title", "titles",
+                               "publisher", "publicationYear", "resourceType", "creators", "concreteType"})
+    if other:
+        print(f"  other metadata carried over: {other}")
+    print("======================================================\n")
+
+
+def submit(syn, payload):
+    print("Submitting DOI mint job ...", file=sys.stderr)
+    # POST /doi/async/start wants an AsynchronousRequestBody (a DoiRequest), with
+    # the Doi nested under "doi" -- not the bare Doi object.
+    request = {"concreteType": "org.sagebionetworks.repo.model.doi.v2.DoiRequest",
+               "doi": payload}
+    token = syn.restPOST("/doi/async/start", body=json.dumps(request))["token"]
+    for _ in range(120):
+        time.sleep(2)
+        resp = syn.restGET(f"/doi/async/get/{token}")
+        state = resp.get("jobState")
+        if state in ("PROCESSING", "IN_PROGRESS"):
+            continue
+        if state == "FAILED":
+            raise SystemExit(f"DOI job FAILED: {resp.get('errorMessage') or resp}")
+        print("DOI minted:")
+        print(json.dumps(resp, indent=2))
+        return resp
+    raise SystemExit("Timed out waiting for the DOI job to complete.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--view", help="entity synId (the file view) [prepare mode]")
+    ap.add_argument("--to-version", type=int,
+                    help="already-created snapshot version to mint the new DOI for [prepare mode]")
+    ap.add_argument("--from-version", type=int, default=None,
+                    help="version whose existing DOI to clone metadata from (default: current)")
+    ap.add_argument("--names-from-doi", default=None,
+                    help="DataCite DOI (e.g. 10.7303/syn74341293.1) to source correctly-encoded "
+                         "creator names from -- replaces Synapse-mangled '?' names by position. "
+                         "Synapse GET mangles non-ASCII, so this is how you get clean authors.")
+    ap.add_argument("--out", default="prepared_doi.json",
+                    help="where to write the prepared payload for review")
+    ap.add_argument("--submit", action="store_true",
+                    help="MINT the DOI from --payload (the reviewed JSON). Off by default.")
+    ap.add_argument("--payload", help="reviewed JSON file to submit (required with --submit)")
+    args = ap.parse_args()
+
+    syn = login()
+
+    if args.submit:
+        if not args.payload:
+            raise SystemExit("--submit requires --payload <reviewed JSON file>.")
+        payload = json.load(open(args.payload))
+        print(f"About to mint a DOI for {payload.get('objectId')} "
+              f"version {payload.get('objectVersion')} with {len(payload.get('creators', []))} creators.")
+        submit(syn, payload)
+        return
+
+    # prepare mode
+    if not args.view or args.to_version is None:
+        raise SystemExit("prepare mode needs --view and --to-version.")
+    versions = entity_versions(syn, args.view)
+    if versions and args.to_version not in versions:
+        raise SystemExit(f"version {args.to_version} does not exist for {args.view} "
+                         f"(available: {sorted(versions)}). Create the snapshot first.")
+    existing = fetch_existing_doi(syn, args.view, args.from_version)
+    payload = build_new_payload(existing, args.to_version)
+    if args.names_from_doi:
+        fixed = apply_datacite_names(payload, fetch_datacite_creators(args.names_from_doi))
+        print(f"\nCorrected {len(fixed)} creator name(s) from DataCite {args.names_from_doi}:")
+        for old, new in fixed:
+            print(f"   {old!r}  ->  {new!r}")
+        remaining = [c["creatorName"] for c in payload.get("creators", []) if "?" in c["creatorName"]]
+        if remaining:
+            print(f"   WARNING: {len(remaining)} name(s) still contain '?': {remaining}")
+    summarize(payload, existing)
+    with open(args.out, "w") as f:
+        json.dump(payload, f, indent=2)
+    print(f"Wrote prepared payload to {args.out}")
+    print(f"Review it, then mint with:\n    python {os.path.basename(__file__)} --submit --payload {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/external_scripts/c2m2/verify_c2m2.py
+++ b/external_scripts/c2m2/verify_c2m2.py
@@ -1,0 +1,122 @@
+"""Post-generation sanity checks for a built C2M2 datapackage.
+
+Complements `cfde-c2m2 validate` (schema + frictionless referential checks) with
+data-level checks that matter for this submission: every file has a checksum, no
+private crosswalk/id-map leaked into the package, referential integrity across the
+tables, unique primary keys, and a Synapse-id leak scan (the disease firewall).
+
+Usage:
+    python verify_c2m2.py --package /path/to/c2m2_output [--work /path/with/crosswalks]
+
+Exits non-zero if any HARD check fails; prints WARN/INFO for the rest.
+"""
+import os
+import re
+import glob
+import argparse
+
+import pandas as pd
+
+CORE_TABLES = ["subject", "biosample", "file", "file_describes_biosample"]
+SYNID_RE = re.compile(r"syn\d{6,}")
+
+
+def _read(pkg, name):
+    """Read a C2M2 TSV as all-strings, empty cells as '' (not NaN), or None if absent."""
+    path = os.path.join(pkg, f"{name}.tsv")
+    if not os.path.exists(path):
+        return None
+    return pd.read_csv(path, sep="\t", dtype=str, keep_default_na=False)
+
+
+def _keys(df, ns_col, id_col):
+    return set(zip(df[ns_col], df[id_col]))
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--package", required=True, help="C2M2 output dir (the .tsv tables)")
+    ap.add_argument("--work", default=None, help="dir holding the private id_map/crosswalk CSVs")
+    args = ap.parse_args()
+    pkg = args.package
+
+    failures, warnings = [], []
+
+    def hard(ok, msg):
+        print(f"  [{'PASS' if ok else 'FAIL'}] {msg}")
+        if not ok:
+            failures.append(msg)
+
+    def warn(cond, msg):
+        if cond:
+            print(f"  [WARN] {msg}")
+            warnings.append(msg)
+
+    tables = {t: _read(pkg, t) for t in CORE_TABLES}
+
+    print("== core tables present + non-empty ==")
+    for t in CORE_TABLES:
+        df = tables[t]
+        hard(df is not None and len(df) > 0,
+             f"{t}.tsv present and non-empty ({0 if df is None else len(df)} rows)")
+    if any(tables[t] is None for t in CORE_TABLES):
+        print("\nmissing core tables; aborting further checks")
+        raise SystemExit(1)
+
+    print("== row counts ==")
+    for f in sorted(glob.glob(os.path.join(pkg, "*.tsv"))):
+        n = sum(1 for _ in open(f)) - 1
+        print(f"  {os.path.basename(f):34} {max(n, 0)}")
+
+    print("== every file has a checksum (sha256 or md5) ==")
+    fdf = tables["file"]
+    sha = fdf["sha256"] if "sha256" in fdf.columns else pd.Series([""] * len(fdf))
+    md5 = fdf["md5"] if "md5" in fdf.columns else pd.Series([""] * len(fdf))
+    missing = ((sha.fillna("") == "") & (md5.fillna("") == "")).sum()
+    hard(missing == 0, f"file rows missing BOTH sha256 and md5: {missing}")
+
+    print("== primary keys unique (id_namespace, local_id) ==")
+    for t in ["subject", "biosample", "file"]:
+        df = tables[t]
+        if {"id_namespace", "local_id"} <= set(df.columns):
+            dups = len(df) - len(df.drop_duplicates(["id_namespace", "local_id"]))
+            hard(dups == 0, f"{t}.tsv duplicate primary keys: {dups}")
+
+    print("== referential integrity ==")
+    file_keys = _keys(fdf, "id_namespace", "local_id")
+    bio_keys = _keys(tables["biosample"], "id_namespace", "local_id")
+    fdb = tables["file_describes_biosample"]
+    orphan_files = _keys(fdb, "file_id_namespace", "file_local_id") - file_keys
+    orphan_bios = _keys(fdb, "biosample_id_namespace", "biosample_local_id") - bio_keys
+    hard(not orphan_files, f"file_describes_biosample -> file orphans: {len(orphan_files)}")
+    hard(not orphan_bios, f"file_describes_biosample -> biosample orphans: {len(orphan_bios)}")
+    bd = _read(pkg, "biosample_disease")
+    if bd is not None and len(bd):
+        orphan_bd = _keys(bd, "biosample_id_namespace", "biosample_local_id") - bio_keys
+        hard(not orphan_bd, f"biosample_disease -> biosample orphans: {len(orphan_bd)}")
+
+    print("== disease firewall: no private crosswalk/id-map inside the package ==")
+    leaked = [os.path.basename(p) for p in glob.glob(os.path.join(pkg, "*"))
+              if re.search(r"crosswalk|id_map", os.path.basename(p), re.I)]
+    hard(not leaked, f"crosswalk/id_map files inside package: {leaked}")
+
+    print("== Synapse-id leak scan (warn) ==")
+    syn_hits = {}
+    for f in glob.glob(os.path.join(pkg, "*.tsv")):
+        with open(f) as fh:
+            c = sum(len(SYNID_RE.findall(line)) for line in fh)
+        if c:
+            syn_hits[os.path.basename(f)] = c
+    warn(bool(syn_hits), f"Synapse ids appear in package tables: {syn_hits} "
+                         "(controlled raw-audio rows must NOT carry synIds)")
+
+    print("== leading zeros preserved in subject local_ids (eyeball) ==")
+    print("  sample:", list(tables["subject"]["local_id"].head(5)))
+
+    print(f"\n=== {'PASS' if not failures else 'FAIL'}: "
+          f"{len(failures)} failure(s), {len(warnings)} warning(s) ===")
+    raise SystemExit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/external_scripts/sage_upload_scripts/README.md
+++ b/external_scripts/sage_upload_scripts/README.md
@@ -51,7 +51,23 @@ Files whose MD5 already matches what is on Sage are skipped, so re-running an up
 
 The old approach of splitting the manifest by `--start`/`--end` row ranges tended to fail with concurrent-upload errors because rows for the *same* folder landed in different jobs, which then raced to create that folder. Uploading **one subject per job** avoids this: the only shared parent is the dataset folder, which already exists.
 
-`sage_upload_array.sbatch` is a SLURM array job that uploads one subject per array task. The partition is set to `pi_satra` (up to 48h); `ou_bcs_normal` (up to 24h) is an alternative. The per-task `--time` is generous for a single subject. Output goes to the repo `logs/` directory.
+Scheduler submission scripts are **site-specific and deliberately not in this repository**
+(`.gitignore` excludes `external_scripts/sage_upload_scripts/*.sbatch` and `*.sh`), so write your own
+for your cluster. What it has to do:
+
+- Take the manifest, a subject list, and a chunk size as arguments.
+- Map each array task to a disjoint set of subjects — `SLURM_ARRAY_TASK_ID` selects a slice of the
+  subject list — and call `sage_upload_manifest.py --subject` once per subject in that slice. One
+  subject per folder subtree is what avoids the race; never split a single subject across tasks.
+- Size the array to `ceil(n_subjects / chunk)`. Chunk more than one subject per task when the subject
+  count exceeds your queue's submitted-job cap (256 on `pi_satra`), and cap concurrency with `%N` so a
+  burst of parallel uploads does not trip Synapse rate limits — `%20` has worked.
+- Request modest resources (2 CPUs, ~4 GB, a few hours per task) and write per-task stdout/stderr to a
+  log directory outside the repository.
+- Leave the dataset-level files to a single post-array run of `--toplevel`; they are not subject-scoped
+  and must not be uploaded concurrently from many tasks.
+
+The full flow:
 
 ```
 # 1. Generate the manifest once (step 1 above), e.g. to manifest.tsv
@@ -62,9 +78,9 @@ ls -d path/to/bids/folder/sub-* | xargs -n1 basename > subjects.txt
 python sage_upload_manifest.py --manifest_file manifest.tsv \
     --subject "$(head -1 subjects.txt)" --dry_run
 
-# 4. Submit the array, sized to the subject count and capped at 20 concurrent (%20)
-sbatch --array=0-$(($(wc -l < subjects.txt) - 1))%20 \
-    sage_upload_array.sbatch manifest.tsv subjects.txt
+# 4. Submit your own array job over subjects.txt, capping concurrency (e.g. %20).
+#    Each task runs, for each subject in its slice:
+#      python sage_upload_manifest.py --manifest_file manifest.tsv --subject "$SUBJECT"
 
 # 5. After the array finishes, upload the dataset-level files once
 python sage_upload_manifest.py --manifest_file manifest.tsv --toplevel
@@ -91,6 +107,8 @@ python verify_sage_contents.py \
 `--adult` is a flag to specify whether to check that the Sage folder to compare against is for the adult data. Leave off the flag for checking the pediatric data.
 
 `--get_md5` is a flag to specify whether to generate MD5 hashes of the files in the BIDS folder. If specified, it will generate the hash for the local files and compare it against the corresponding Sage file's MD5 hash.
+
+This script **reports**; it does not gate. Its normal use is diagnostic — deciding whether an upload needs re-running or a stale local cache needs pruning — so differences are logged and the script exits successfully. A mismatch means the bytes on Sage are not the bytes you have locally: a truncated or corrupted upload, a local file regenerated after upload, or an older version still on Sage. Pass `--strict` when the outcome must fail something automated; it exits non-zero if any file is on Sage but missing locally, present locally but not on Sage, has a differing md5, or has no server-side md5 to compare against when `--get_md5` was requested. That last case matters: without it, a comparison that silently never happened looks the same as one that passed.
 
 `--subject sub-XXXX` restricts the comparison to a single subject's subtree for a quick spot check (e.g. confirming one subject's metadata re-uploaded), instead of walking the entire dataset. It scopes both the local and Sage walks to `<bids_folder>/sub-XXXX`.
 

--- a/external_scripts/sage_upload_scripts/verify_sage_contents.py
+++ b/external_scripts/sage_upload_scripts/verify_sage_contents.py
@@ -187,10 +187,15 @@ def run_folder_comparisons(syn, sage_folders, local_folders, dry_run=True):
 
 
 def run_file_comparisons(syn, sage_files, local_files, md5=False, dry_run=True):
+    """Report differences. Returns a count of integrity problems (missing locally,
+    md5 mismatch, or no server md5 to compare when --get_md5 was requested) so a
+    caller can escalate; the reporting itself is unchanged."""
+    problems = 0
     for f in sage_files:
         sage_path = f
         if not os.path.exists(sage_path):
             logger.info("Sage ID %s (%s) not found locally", sage_files[f]['id'], sage_path)
+            problems += 1
         elif not os.path.isfile(sage_path):
             logger.warning("Sage ID %s (%s) found locally but is not a file",
                            sage_files[f]['id'], sage_path)
@@ -199,9 +204,11 @@ def run_file_comparisons(syn, sage_files, local_files, md5=False, dry_run=True):
             if not _has_md5(smd5):
                 logger.warning("Sage ID %s (%s) has no server md5 to compare against",
                                sage_files[f]['id'], sage_path)
+                problems += 1
             elif smd5 != lmd5:
                 logger.info("Sage ID %s (%s) md5 (%s) does not match local md5 hash (%s)",
                             sage_files[f]['id'], sage_path, smd5, lmd5)
+                problems += 1
 
     sage_file_set = set(sage_files.keys())
     local_file_set = set(local_files.keys())
@@ -214,11 +221,14 @@ def run_file_comparisons(syn, sage_files, local_files, md5=False, dry_run=True):
         for path in sage_only:
             logger.info("\t%s (id %s)", path, sage_files[path]['id'])
             delete_from_sage(syn, sage_files[path]['id'], path, dry_run=dry_run)
-    if local_file_set - sage_file_set:
+    local_only = local_file_set - sage_file_set
+    if local_only:
         logger.info("The following files were found locally and not on Sage "
                     "(re-run the upload manifest flow to add them to Sage):")
-        for path in (local_file_set - sage_file_set):
+        for path in local_only:
             logger.info("\t%s", path)
+        problems += len(local_only)
+    return problems
 
 
 def build_from_view(syn, config, bids_folder):
@@ -302,6 +312,13 @@ def main():
                         help='Local BIDS folder to compare against Synapse.')
     parser.add_argument('--adult', default=False, action='store_true',
                         help='Target the adult dataset. Omit for the pediatric dataset.')
+    parser.add_argument('--strict', default=False, action='store_true',
+                        help='Exit non-zero if any integrity problem is found (file on Sage but '
+                             'missing locally, md5 mismatch, no server md5 to compare against with '
+                             '--get_md5, or file present locally but not on Sage). Off by default: '
+                             'this script is normally read as a diagnostic for deciding whether to '
+                             're-run an upload or prune a stale cache, and it reports rather than '
+                             'gates. Use --strict when the result must fail a pipeline.')
     parser.add_argument('--get_md5', default=False, action='store_true',
                         help='Compute local MD5 hashes and compare them to the Synapse files.')
     parser.add_argument('--sync', default=False, action='store_true',
@@ -365,8 +382,13 @@ def main():
 
     # Delete files before folders so cascading folder deletes don't trip over
     # children that were already trashed.
-    run_file_comparisons(syn, synapse_files, local_files, md5=md5, dry_run=dry_run)
+    problems = run_file_comparisons(syn, synapse_files, local_files, md5=md5, dry_run=dry_run)
     run_folder_comparisons(syn, synapse_folders, local_folders, dry_run=dry_run)
+
+    if problems:
+        logger.info("%d file integrity problem(s) reported above.", problems)
+        if args.strict:
+            raise SystemExit(f"--strict: {problems} file integrity problem(s); see the log above.")
 
 
 if __name__=='__main__':

--- a/src/b2aiprep/prepare/resources/feature_schemas/ppgs.json
+++ b/src/b2aiprep/prepare/resources/feature_schemas/ppgs.json
@@ -21,7 +21,7 @@
       "description": "Number of time frames in the PPG tensor (variable per recording)."
     },
     {
-      "name": "ppg",
+      "name": "ppgs",
       "type": "array",
       "description": "Phonetic posteriorgram probabilities across 40 phoneme categories.",
       "extras": {

--- a/src/b2aiprep/prepare/resources/feature_schemas/torchaudio_spectrogram.json
+++ b/src/b2aiprep/prepare/resources/feature_schemas/torchaudio_spectrogram.json
@@ -21,7 +21,7 @@
       "description": "Number of time frames in the spectrogram (variable per recording)."
     },
     {
-      "name": "spectrograms",
+      "name": "spectrogram",
       "type": "array",
       "description": "2D tensor representing the log-magnitude spectrogram.",
       "extras": {

--- a/tests/test_feature_schema_fields.py
+++ b/tests/test_feature_schema_fields.py
@@ -1,60 +1,34 @@
-"""The payload column of each bundled feature file is named after the feature, not the file.
+"""Each feature data dictionary must name the column its parquet actually has.
 
-`create_bundled_dataset` writes one parquet per entry in its `features_to_extract` list,
-naming the file `{feature_class}_{feature_name}` (or just `{feature_name}` when there is no
-class) and the payload column `{feature_name}` -- see `bundle_data.feature_extraction_generator`,
-which does `output[feature_name] = data`.
+The payload column is the file name minus its backend prefix -- `ppgs.parquet` holds
+`ppgs`, `torchaudio_spectrogram.parquet` holds `spectrogram`, `sparc_ema.parquet` holds
+`ema` -- because `create_bundled_dataset` writes `output[feature_name] = data` and names
+the file `{feature_class}_{feature_name}`.
 
-The shipped data dictionary for each file must therefore declare a payload field whose name is
-exactly that `feature_name`. Two dictionaries drifted from this (`ppgs.json` declared `ppg`,
-`torchaudio_spectrogram.json` declared `spectrograms`), so every published copy of those two
-files documented a column that did not exist. This test pins the rule.
+Two dictionaries had drifted from that in opposite directions (`ppgs.json` declared
+`ppg`, `torchaudio_spectrogram.json` declared `spectrograms`), so every published copy of
+those files documented a column no reader can find. Validating a dictionary against the
+data file itself needs a built release; this only pins the naming rule, which is the part
+that can regress in a pull request.
 """
 
 import json
-import re
 from pathlib import Path
 
-import pytest
-
-# Read the tree this test lives in, not the installed package: the point is to check the
-# dictionaries shipped alongside this checkout's code.
-_SRC = Path(__file__).resolve().parents[1] / "src" / "b2aiprep"
-
-# Columns every feature parquet carries regardless of the feature itself.
+_SCHEMAS = (
+    Path(__file__).resolve().parents[1]
+    / "src" / "b2aiprep" / "prepare" / "resources" / "feature_schemas"
+)
 _INDEX_FIELDS = {"participant_id", "session_id", "task_name", "n_frames"}
 
-_FEATURE_ENTRY = re.compile(
-    r"\{'feature_class': (None|'[a-z_]+'), 'feature_name': '([a-z_]+)'\}"
-)
 
-
-def _features_to_extract():
-    """Read the (feature_class, feature_name) pairs the bundler actually iterates."""
-    source = (_SRC / "commands.py").read_text()
-    pairs = _FEATURE_ENTRY.findall(source)
-    assert pairs, "could not locate features_to_extract in commands.py"
-    return [(None if c == "None" else c.strip("'"), n) for c, n in pairs]
-
-
-def _schema_fields(alias):
-    path = _SRC / "prepare" / "resources" / "feature_schemas" / f"{alias}.json"
-    return json.loads(path.read_text())["fields"]
-
-
-@pytest.mark.parametrize("feature_class,feature_name", _features_to_extract())
-def test_payload_field_is_named_after_the_feature(feature_class, feature_name):
-    alias = f"{feature_class}_{feature_name}" if feature_class else feature_name
-    payload = [f["name"] for f in _schema_fields(alias) if f["name"] not in _INDEX_FIELDS]
-    assert payload == [feature_name], (
-        f"{alias}.json declares payload field(s) {payload}; the bundled column is "
-        f"'{feature_name}'. The dictionary must name the column the file actually has."
-    )
-
-
-@pytest.mark.parametrize("feature_class,feature_name", _features_to_extract())
-def test_index_fields_present(feature_class, feature_name):
-    alias = f"{feature_class}_{feature_name}" if feature_class else feature_name
-    names = {f["name"] for f in _schema_fields(alias)}
-    missing = _INDEX_FIELDS - names
-    assert not missing, f"{alias}.json is missing index field(s) {sorted(missing)}"
+def test_payload_field_matches_file_name():
+    paths = sorted(_SCHEMAS.glob("*.json"))
+    assert paths, f"no feature dictionaries found in {_SCHEMAS}"
+    for path in paths:
+        fields = json.loads(path.read_text())["fields"]
+        payload = [f["name"] for f in fields if f["name"] not in _INDEX_FIELDS]
+        assert len(payload) == 1 and path.stem.endswith(payload[0]), (
+            f"{path.name} declares payload field(s) {payload}; the column is the file "
+            f"name minus its backend prefix, so it must end with the declared name"
+        )

--- a/tests/test_feature_schema_fields.py
+++ b/tests/test_feature_schema_fields.py
@@ -1,0 +1,60 @@
+"""The payload column of each bundled feature file is named after the feature, not the file.
+
+`create_bundled_dataset` writes one parquet per entry in its `features_to_extract` list,
+naming the file `{feature_class}_{feature_name}` (or just `{feature_name}` when there is no
+class) and the payload column `{feature_name}` -- see `bundle_data.feature_extraction_generator`,
+which does `output[feature_name] = data`.
+
+The shipped data dictionary for each file must therefore declare a payload field whose name is
+exactly that `feature_name`. Two dictionaries drifted from this (`ppgs.json` declared `ppg`,
+`torchaudio_spectrogram.json` declared `spectrograms`), so every published copy of those two
+files documented a column that did not exist. This test pins the rule.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+# Read the tree this test lives in, not the installed package: the point is to check the
+# dictionaries shipped alongside this checkout's code.
+_SRC = Path(__file__).resolve().parents[1] / "src" / "b2aiprep"
+
+# Columns every feature parquet carries regardless of the feature itself.
+_INDEX_FIELDS = {"participant_id", "session_id", "task_name", "n_frames"}
+
+_FEATURE_ENTRY = re.compile(
+    r"\{'feature_class': (None|'[a-z_]+'), 'feature_name': '([a-z_]+)'\}"
+)
+
+
+def _features_to_extract():
+    """Read the (feature_class, feature_name) pairs the bundler actually iterates."""
+    source = (_SRC / "commands.py").read_text()
+    pairs = _FEATURE_ENTRY.findall(source)
+    assert pairs, "could not locate features_to_extract in commands.py"
+    return [(None if c == "None" else c.strip("'"), n) for c, n in pairs]
+
+
+def _schema_fields(alias):
+    path = _SRC / "prepare" / "resources" / "feature_schemas" / f"{alias}.json"
+    return json.loads(path.read_text())["fields"]
+
+
+@pytest.mark.parametrize("feature_class,feature_name", _features_to_extract())
+def test_payload_field_is_named_after_the_feature(feature_class, feature_name):
+    alias = f"{feature_class}_{feature_name}" if feature_class else feature_name
+    payload = [f["name"] for f in _schema_fields(alias) if f["name"] not in _INDEX_FIELDS]
+    assert payload == [feature_name], (
+        f"{alias}.json declares payload field(s) {payload}; the bundled column is "
+        f"'{feature_name}'. The dictionary must name the column the file actually has."
+    )
+
+
+@pytest.mark.parametrize("feature_class,feature_name", _features_to_extract())
+def test_index_fields_present(feature_class, feature_name):
+    alias = f"{feature_class}_{feature_name}" if feature_class else feature_name
+    names = {f["name"] for f in _schema_fields(alias)}
+    missing = _INDEX_FIELDS - names
+    assert not missing, f"{alias}.json is missing index field(s) {sorted(missing)}"


### PR DESCRIPTION
Three unrelated defects plus two scripts that were never committed. No behaviour changes to the pipeline.

### Two data dictionaries named columns that do not exist

`ppgs.json` declared field `ppg` where the bundled parquet column is `ppgs`, and `torchaudio_spectrogram.json` declared `spectrograms` where the column is `spectrogram`. Every published copy of those two files therefore documented a column no reader can find. The other seven were correct.

The rule the data follows is that the payload column is named after the feature — `feature_name` in the `features_to_extract` list in `commands.py`, which is also the filename minus its backend prefix. That holds for all nine, so this was never a plural-versus-singular question; the two dictionaries had drifted in opposite directions.

`tests/test_feature_schema_fields.py` pins the rule for all nine files. It needs no data fixtures — it reads the code's own feature list — and it fails if either bug is reintroduced.

### `verify_sage_contents.py` had no way to fail

It logged md5 mismatches at info level and exited 0, and an absent server-side md5 — a comparison that silently never happened — was only a warning.

**Default behaviour is unchanged**, because this script is normally read as a diagnostic for deciding whether to re-run an upload or prune a stale local cache. It now counts integrity problems and accepts `--strict` to exit non-zero, for callers that need the result to fail something automated.

### The README invoked a `.sbatch` that is deliberately not in the repo

`.gitignore` excludes all `*.sh` and `*.sbatch` under `sage_upload_scripts/`, since scheduler scripts are site-specific. Replaced the invocation with a description of what such a job must do: disjoint subject slices, array sized to the subject count, chunking to stay under the queue's submitted-job cap, concurrency capped to avoid rate limits, and dataset-level files left to a single post-array `--toplevel` run.

### `prepare_doi.py` and `verify_c2m2.py` committed

Both were written during the June 2026 C2M2 submission and left untracked in a working checkout, so neither was discoverable from the repository.

`verify_c2m2.py` adds the data-level checks `cfde-c2m2 validate` does not do: checksum coverage, primary-key uniqueness, `file_describes_biosample` orphans on either side, no crosswalk or id-map inside the package, and no Synapse ids in the tables. That last one is the disease firewall, so it belongs in version control.

`prepare_doi.py` versions the citation DOI that the controlled-access step depends on. It clones the existing DOI so the creator list and title carry over, strips server-assigned fields, and is two-step: prepare is read-only, minting requires `--submit` against the reviewed JSON.

Both are documented in `external_scripts/c2m2/README.md`, including three things not obvious from the code: the snapshot must exist before preparing, Synapse mangles non-ASCII creator names on GET so `--names-from-doi` sources them from DataCite, and PII screening must precede a snapshot because deleting a file later does not scrub its metadata from an already-DOI'd snapshot.

No secrets, cluster paths, or identifiers beyond what the repository already publishes: auth comes from `SAGE_PAT`/`SYNAPSE_PAT`, the private crosswalk directory is a runtime argument, and the one synId in a docstring example is a view whose DOI is public by definition.
