### PR TITLE
Make acoustic_task_id a deterministic UUID keyed by session and task

### DIFF
--- a/src/b2aiprep/prepare/redcap.py
+++ b/src/b2aiprep/prepare/redcap.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import typing as t
+import uuid
 from collections import OrderedDict
 from datetime import datetime
 from pathlib import Path
@@ -458,6 +459,12 @@ def parse_audio(audio_list, dummy_audio_files=False, is_import=False):
     flattened_list = [value for key in protocol_order for value in protocol_order[key]]
     flattened_list = _select_latest_duplicate_recordings(flattened_list, dummy_audio_files)
 
+    # Deterministic (uuid5) so re-processing the same session/task never mints a
+    # new id -- the acoustic task and its recordings must keep matching join keys
+    # across repeated pipeline runs.
+    def acoustic_task_uuid(session_value, task_name):
+        return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"{session_value}:{task_name}"))
+
     audio_output_list = []
     count = 1
     acoustic_task_count = 1
@@ -509,7 +516,7 @@ def parse_audio(audio_list, dummy_audio_files=False, is_import=False):
                 "record_id": record_id,
                 "redcap_repeat_instrument": "Acoustic Task",
                 "redcap_repeat_instance": acoustic_task_count,
-                "acoustic_task_id": f"{session}",
+                "acoustic_task_id": acoustic_task_uuid(session, acoustic_task),
                 "acoustic_task_session_id": session,
                 "acoustic_task_name": acoustic_task,
                 "acoustic_task_cohort": "Pediatric",
@@ -558,7 +565,7 @@ def parse_audio(audio_list, dummy_audio_files=False, is_import=False):
             "redcap_repeat_instrument": "Recording",
             "redcap_repeat_instance": count,
             "recording_id": recording_id,
-            "recording_acoustic_task_id": f"{session}",
+            "recording_acoustic_task_id": acoustic_task_uuid(session, acoustic_task),
             "recording_session_id": session,
             "recording_name": recording_name,
             "recording_duration": duration,
@@ -770,9 +777,6 @@ class RedCapDataset:
         # session_id: remove the trailing "-"
         for col in df.columns:
             if col.endswith("session_id"):
-                df[col] = df[col].astype(str).str.replace(r'-$', '', regex=True)
-            if col.endswith("acoustic_task_id"):
-                # session was the suffix, so remove it here too
                 df[col] = df[col].astype(str).str.replace(r'-$', '', regex=True)
         
         # tasks: remove "_task" from all task_id and task_name columns

--- a/tests/test_ui2redcap_csv.py
+++ b/tests/test_ui2redcap_csv.py
@@ -1,3 +1,5 @@
+import uuid
+
 import numpy as np
 from b2aiprep.prepare.redcap import parse_survey, parse_audio
 import pandas as pd
@@ -69,7 +71,7 @@ def test_audio_csv():
             "record_id": "99999",
             "redcap_repeat_instrument": "Acoustic Task",
             "redcap_repeat_instance": 1,
-            "acoustic_task_id": "14829893-3879-4723-932b-d98d6bc356a8-",
+            "acoustic_task_id": "69127781-5c56-544f-9465-39a9fe2b39e6",
             "acoustic_task_session_id": "14829893-3879-4723-932b-d98d6bc356a8-",
             "acoustic_task_name": "long_sounds_task",
             "acoustic_task_cohort": "Pediatric",
@@ -84,7 +86,7 @@ def test_audio_csv():
             "redcap_repeat_instrument": "Recording",
             "redcap_repeat_instance": 1,
             "recording_id": "d6d7411f-c934-4bca-91a7-5ddad353b801",
-            "recording_acoustic_task_id": "14829893-3879-4723-932b-d98d6bc356a8-",
+            "recording_acoustic_task_id": "69127781-5c56-544f-9465-39a9fe2b39e6",
             "recording_session_id": "14829893-3879-4723-932b-d98d6bc356a8-",
             "recording_name": "long_sounds_task-1",
             "recording_duration": 0,
@@ -104,7 +106,7 @@ def test_audio_csv():
             "redcap_repeat_instrument": "Recording",
             "redcap_repeat_instance": 2,
             "recording_id": "69181d90-aae4-49d0-861d-4ff4a939bff0",
-            "recording_acoustic_task_id": "14829893-3879-4723-932b-d98d6bc356a8-",
+            "recording_acoustic_task_id": "69127781-5c56-544f-9465-39a9fe2b39e6",
             "recording_session_id": "14829893-3879-4723-932b-d98d6bc356a8-",
             "recording_name": "long_sounds_task-2",
             "recording_duration": 0,
@@ -123,6 +125,44 @@ def test_audio_csv():
 
     actual = parse_audio(audio_files, True, is_import=False)
     assert expected_output == actual
+
+
+def test_acoustic_task_id_is_stable_uuid_per_session_and_task():
+    """acoustic_task_id must be a UUID, identical across reruns for the same
+    (session, task), and distinct across different tasks in the same session."""
+    audio_files = [
+        "./mock_audio/99999/14829893-3879-4723-932b-d98d6bc356a8-/long_sounds_task_1_10_plus-d6d7411f-c934-4bca-91a7-5ddad353b801.wav",
+        "./mock_audio/99999/14829893-3879-4723-932b-d98d6bc356a8-/silly_sounds_task_1_10_plus-69181d90-aae4-49d0-861d-4ff4a939bff0.wav",
+    ]
+
+    first_run = parse_audio(audio_files, True, is_import=False)
+    second_run = parse_audio(audio_files, True, is_import=False)
+
+    task_ids = {
+        row["acoustic_task_name"]: row["acoustic_task_id"]
+        for row in first_run
+        if row["redcap_repeat_instrument"] == "Acoustic Task"
+    }
+    task_ids_rerun = {
+        row["acoustic_task_name"]: row["acoustic_task_id"]
+        for row in second_run
+        if row["redcap_repeat_instrument"] == "Acoustic Task"
+    }
+
+    # rerunning on the same data must not mint new ids
+    assert task_ids == task_ids_rerun
+    # different tasks in the same session must get different ids
+    assert len(set(task_ids.values())) == len(task_ids)
+    # ids look like uuids, not the raw session string
+    for task_id in task_ids.values():
+        assert uuid.UUID(task_id)
+
+    recording_task_ids = {
+        row["recording_id"]: row["recording_acoustic_task_id"] for row in first_run
+        if row["redcap_repeat_instrument"] == "Recording"
+    }
+    assert recording_task_ids["d6d7411f-c934-4bca-91a7-5ddad353b801"] == task_ids["long_sounds_task"]
+    assert recording_task_ids["69181d90-aae4-49d0-861d-4ff4a939bff0"] == task_ids["silly_sounds_task"]
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Previously acoustic_task_id was just the session folder name, so every acoustic task within a session shared the same id. Derive it instead via uuid5(session, acoustic_task) so each task gets its own stable id, reprocessing the same data never mints a new id, and the Recording -> Acoustic Task join key stays correct.